### PR TITLE
feat(skald): Skald screen UI shell (#9)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ForgeScreen } from './screens/forge'
+import { GreatHallScreen } from './screens/great-hall'
 import { IronSheetScreen } from './screens/iron-sheet'
 import { OracleScreen } from './screens/oracle'
 import { SkaldScreen } from './screens/skald'
@@ -8,11 +9,12 @@ export function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/great-hall" element={<GreatHallScreen />} />
         <Route path="/forge" element={<ForgeScreen />} />
         <Route path="/iron-sheet" element={<IronSheetScreen />} />
         <Route path="/oracle" element={<OracleScreen />} />
         <Route path="/skald" element={<SkaldScreen />} />
-        <Route path="*" element={<Navigate to="/forge" replace />} />
+        <Route path="*" element={<Navigate to="/great-hall" replace />} />
       </Routes>
     </BrowserRouter>
   )

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ForgeScreen } from './screens/forge'
 import { IronSheetScreen } from './screens/iron-sheet'
 import { OracleScreen } from './screens/oracle'
+import { SkaldScreen } from './screens/skald'
 
 export function App() {
   return (
@@ -10,6 +11,7 @@ export function App() {
         <Route path="/forge" element={<ForgeScreen />} />
         <Route path="/iron-sheet" element={<IronSheetScreen />} />
         <Route path="/oracle" element={<OracleScreen />} />
+        <Route path="/skald" element={<SkaldScreen />} />
         <Route path="*" element={<Navigate to="/forge" replace />} />
       </Routes>
     </BrowserRouter>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { NarrativeDomainProvider } from './providers/NarrativeDomainProvider'
 import { App } from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <NarrativeDomainProvider>
+      <App />
+    </NarrativeDomainProvider>
   </React.StrictMode>
 )

--- a/apps/web/src/providers/NarrativeDomainProvider.campaignOps.test.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.campaignOps.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { NarrativeDomainProvider, useCampaignOps } from './NarrativeDomainProvider'
+import type { CampaignSummary, Campaign, CharacterState, SessionEvent } from '@saga-keeper/domain'
+
+// ── Storage mock setup ────────────────────────────────────────────────────────
+
+const mockList: Mock = vi.fn()
+const mockCampaignGet: Mock = vi.fn()
+const mockCharacterGet: Mock = vi.fn()
+const mockSessionGetRecent: Mock = vi.fn()
+
+vi.mock('@saga-keeper/storage', () => ({
+  LocalAdapter: vi.fn(() => ({
+    campaigns: {
+      list: mockList,
+      get: mockCampaignGet,
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    characters: { get: mockCharacterGet, save: vi.fn() },
+    session: {
+      getRecent: mockSessionGetRecent,
+      append: vi.fn(),
+      appendBatch: vi.fn(),
+      getAll: vi.fn(),
+    },
+    world: { list: vi.fn(), get: vi.fn(), save: vi.fn(), delete: vi.fn() },
+    export: vi.fn(),
+    import: vi.fn(async () => makeCampaign()),
+  })),
+}))
+
+vi.mock('@saga-keeper/services', () => ({
+  NarrativeDomain: vi.fn(() => ({ processTurn: vi.fn() })),
+  OracleService: vi.fn(() => ({})),
+  DiceService: {},
+}))
+
+vi.mock('@saga-keeper/ruleset-ironsworn', () => ({
+  ironswornPlugin: {},
+}))
+
+vi.mock('./OfflineAIGateway', () => ({
+  OfflineAIGateway: vi.fn(() => ({
+    getTier: () => 'offline',
+    getCapabilities: () => ({ localOnly: true, streaming: false, maxContextTokens: 0, supportsSystemPrompt: false }),
+    complete: vi.fn(),
+    stream: vi.fn(),
+  })),
+}))
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+function makeSummary(): CampaignSummary {
+  return {
+    id: 'c1',
+    name: 'The Ashwood Oath',
+    rulesetId: 'ironsworn-v1',
+    status: 'active',
+    mode: 'solo',
+    characterIds: ['ch1'],
+  }
+}
+
+function makeCampaign(): Campaign {
+  return {
+    id: 'c1',
+    name: 'The Ashwood Oath',
+    rulesetId: 'ironsworn-v1',
+    status: 'active',
+    mode: 'solo',
+    characterIds: ['ch1'],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function makeCharacter(): CharacterState {
+  return {
+    id: 'ch1',
+    campaignId: 'c1',
+    name: 'Björn',
+    rulesetId: 'ironsworn-v1',
+    data: {},
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <NarrativeDomainProvider>{children}</NarrativeDomainProvider>
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockList.mockResolvedValue([])
+  mockCampaignGet.mockResolvedValue(makeCampaign())
+  mockCharacterGet.mockResolvedValue(makeCharacter())
+  mockSessionGetRecent.mockResolvedValue([])
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useCampaignOps — listCampaigns', () => {
+  it('returns the list from storage', async () => {
+    const summaries: CampaignSummary[] = [makeSummary()]
+    mockList.mockResolvedValueOnce(summaries)
+    const { result } = renderHook(() => useCampaignOps(), { wrapper })
+    const list = await result.current.listCampaigns()
+    expect(mockList).toHaveBeenCalledOnce()
+    expect(list).toEqual(summaries)
+  })
+
+  it('returns an empty array when storage has no campaigns', async () => {
+    mockList.mockResolvedValueOnce([])
+    const { result } = renderHook(() => useCampaignOps(), { wrapper })
+    const list = await result.current.listCampaigns()
+    expect(list).toEqual([])
+  })
+})
+
+describe('useCampaignOps — loadCampaign', () => {
+  it('fetches campaign, first character, and recent events', async () => {
+    const campaign = makeCampaign()
+    const character = makeCharacter()
+    const events: SessionEvent[] = []
+    mockCampaignGet.mockResolvedValueOnce(campaign)
+    mockCharacterGet.mockResolvedValueOnce(character)
+    mockSessionGetRecent.mockResolvedValueOnce(events)
+
+    const { result } = renderHook(() => useCampaignOps(), { wrapper })
+    const loaded = await result.current.loadCampaign('c1')
+
+    expect(mockCampaignGet).toHaveBeenCalledWith('c1')
+    expect(mockCharacterGet).toHaveBeenCalledWith('ch1')
+    expect(mockSessionGetRecent).toHaveBeenCalledWith('c1', 20)
+    expect(loaded.campaign).toEqual(campaign)
+    expect(loaded.character).toEqual(character)
+    expect(loaded.events).toEqual(events)
+  })
+})
+
+describe('useCampaignOps — outside provider', () => {
+  it('throws when called outside NarrativeDomainProvider', () => {
+    function Thrower() {
+      try {
+        useCampaignOps()
+        return <div>no error</div>
+      } catch (e) {
+        return <div data-testid="error">{(e as Error).message}</div>
+      }
+    }
+    render(<Thrower />)
+    expect(screen.getByTestId('error').textContent).toMatch(/useCampaignOps must be called inside/i)
+  })
+})

--- a/apps/web/src/providers/NarrativeDomainProvider.test.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { NarrativeDomainProvider, useNarrativeDomain } from './NarrativeDomainProvider'
+import { NarrativeDomainProvider, useNarrativeDomain, usePersistSetup } from './NarrativeDomainProvider'
 
 // ── Helper component that calls the hook ──────────────────────────────────────
 
@@ -34,6 +34,21 @@ describe('NarrativeDomainProvider', () => {
     render(<ThrowerOutsideProvider />)
     expect(screen.getByTestId('error').textContent).toMatch(
       /useNarrativeDomain must be called inside/i,
+    )
+  })
+
+  it('throws when usePersistSetup is called outside provider', () => {
+    function PersistSetupOutside() {
+      try {
+        usePersistSetup()
+        return <div>no error</div>
+      } catch (e) {
+        return <div data-testid="persist-error">{(e as Error).message}</div>
+      }
+    }
+    render(<PersistSetupOutside />)
+    expect(screen.getByTestId('persist-error').textContent).toMatch(
+      /usePersistSetup must be called inside/i,
     )
   })
 })

--- a/apps/web/src/providers/NarrativeDomainProvider.test.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NarrativeDomainProvider, useNarrativeDomain } from './NarrativeDomainProvider'
+
+// ── Helper component that calls the hook ──────────────────────────────────────
+
+function Inspector() {
+  const domain = useNarrativeDomain()
+  return <div data-testid="result">{typeof domain.processTurn}</div>
+}
+
+function ThrowerOutsideProvider() {
+  try {
+    useNarrativeDomain()
+    return <div>no error</div>
+  } catch (e) {
+    return <div data-testid="error">{(e as Error).message}</div>
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('NarrativeDomainProvider', () => {
+  it('provides a domain with processTurn function', () => {
+    render(
+      <NarrativeDomainProvider>
+        <Inspector />
+      </NarrativeDomainProvider>,
+    )
+    expect(screen.getByTestId('result').textContent).toBe('function')
+  })
+
+  it('throws when useNarrativeDomain is called outside provider', () => {
+    render(<ThrowerOutsideProvider />)
+    expect(screen.getByTestId('error').textContent).toMatch(
+      /useNarrativeDomain must be called inside/i,
+    )
+  })
+})
+
+describe('OfflineAIGateway', () => {
+  it('getTier returns offline', async () => {
+    const { OfflineAIGateway } = await import('./OfflineAIGateway')
+    const gw = new OfflineAIGateway()
+    expect(gw.getTier()).toBe('offline')
+  })
+
+  it('getCapabilities returns localOnly: true', async () => {
+    const { OfflineAIGateway } = await import('./OfflineAIGateway')
+    const gw = new OfflineAIGateway()
+    expect(gw.getCapabilities().localOnly).toBe(true)
+  })
+
+  it('complete() throws', async () => {
+    const { OfflineAIGateway } = await import('./OfflineAIGateway')
+    const gw = new OfflineAIGateway()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => gw.complete({} as any)).toThrow('must never be called')
+  })
+})

--- a/apps/web/src/providers/NarrativeDomainProvider.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.tsx
@@ -61,7 +61,7 @@ export function NarrativeDomainProvider({ children }: NarrativeDomainProviderPro
       campaignId: string,
     ): Promise<{ campaign: Campaign; character: CharacterState; events: SessionEvent[] }> {
       const campaign = await storage.campaigns.get(campaignId)
-      const character = await storage.characters.get(campaign.characterIds[0])
+      const character = await storage.characters.get(campaign.characterIds[0]!)
       const events = await storage.session.getRecent(campaignId, 20)
       return { campaign, character, events }
     }

--- a/apps/web/src/providers/NarrativeDomainProvider.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.tsx
@@ -2,12 +2,14 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { NarrativeDomain, OracleService, DiceService, type INarrativeDomain } from '@saga-keeper/services'
 import { LocalAdapter } from '@saga-keeper/storage'
 import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
+import type { Campaign, CharacterState } from '@saga-keeper/domain'
 import { OfflineAIGateway } from './OfflineAIGateway'
 
 // ── Context ───────────────────────────────────────────────────────────────────
 
 interface NarrativeDomainContextValue {
   narrativeDomain: INarrativeDomain
+  persistSetup: (campaign: Campaign, character: CharacterState) => Promise<void>
 }
 
 const NarrativeDomainContext = createContext<NarrativeDomainContextValue | null>(null)
@@ -28,16 +30,30 @@ interface NarrativeDomainProviderProps {
  * - OfflineAIGateway.getTier() returns 'offline'; NarrativeDomain skips AI calls entirely
  */
 export function NarrativeDomainProvider({ children }: NarrativeDomainProviderProps) {
-  const narrativeDomain = useMemo(() => {
+  const ctx = useMemo(() => {
     const storage = new LocalAdapter()
     const oracle = new OracleService()
     const ai = new OfflineAIGateway()
     // DiceService is a plain object (not a class) — pass the singleton directly
-    return new NarrativeDomain(storage, ironswornPlugin, ai, oracle, DiceService)
+    const narrativeDomain = new NarrativeDomain(storage, ironswornPlugin, ai, oracle, DiceService)
+
+    async function persistSetup(campaign: Campaign, character: CharacterState): Promise<void> {
+      await storage.import({
+        version: '1',
+        exportedAt: new Date().toISOString(),
+        rulesetId: campaign.rulesetId,
+        campaign,
+        characters: [character],
+        world: [],
+        sessionLog: [],
+      })
+    }
+
+    return { narrativeDomain, persistSetup }
   }, [])
 
   return (
-    <NarrativeDomainContext.Provider value={{ narrativeDomain }}>
+    <NarrativeDomainContext.Provider value={ctx}>
       {children}
     </NarrativeDomainContext.Provider>
   )
@@ -55,4 +71,12 @@ export function useNarrativeDomain(): INarrativeDomain {
     throw new Error('useNarrativeDomain must be called inside a <NarrativeDomainProvider>')
   }
   return ctx.narrativeDomain
+}
+
+export function usePersistSetup(): (campaign: Campaign, character: CharacterState) => Promise<void> {
+  const ctx = useContext(NarrativeDomainContext)
+  if (!ctx) {
+    throw new Error('usePersistSetup must be called inside a <NarrativeDomainProvider>')
+  }
+  return ctx.persistSetup
 }

--- a/apps/web/src/providers/NarrativeDomainProvider.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { NarrativeDomain, OracleService, DiceService, type INarrativeDomain } from '@saga-keeper/services'
 import { LocalAdapter } from '@saga-keeper/storage'
 import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
-import type { Campaign, CharacterState } from '@saga-keeper/domain'
+import type { Campaign, CampaignSummary, CharacterState, SessionEvent } from '@saga-keeper/domain'
 import { OfflineAIGateway } from './OfflineAIGateway'
 
 // ── Context ───────────────────────────────────────────────────────────────────
@@ -10,6 +10,10 @@ import { OfflineAIGateway } from './OfflineAIGateway'
 interface NarrativeDomainContextValue {
   narrativeDomain: INarrativeDomain
   persistSetup: (campaign: Campaign, character: CharacterState) => Promise<void>
+  listCampaigns: () => Promise<CampaignSummary[]>
+  loadCampaign: (
+    campaignId: string,
+  ) => Promise<{ campaign: Campaign; character: CharacterState; events: SessionEvent[] }>
 }
 
 const NarrativeDomainContext = createContext<NarrativeDomainContextValue | null>(null)
@@ -49,7 +53,20 @@ export function NarrativeDomainProvider({ children }: NarrativeDomainProviderPro
       })
     }
 
-    return { narrativeDomain, persistSetup }
+    async function listCampaigns(): Promise<CampaignSummary[]> {
+      return storage.campaigns.list()
+    }
+
+    async function loadCampaign(
+      campaignId: string,
+    ): Promise<{ campaign: Campaign; character: CharacterState; events: SessionEvent[] }> {
+      const campaign = await storage.campaigns.get(campaignId)
+      const character = await storage.characters.get(campaign.characterIds[0])
+      const events = await storage.session.getRecent(campaignId, 20)
+      return { campaign, character, events }
+    }
+
+    return { narrativeDomain, persistSetup, listCampaigns, loadCampaign }
   }, [])
 
   return (
@@ -71,6 +88,14 @@ export function useNarrativeDomain(): INarrativeDomain {
     throw new Error('useNarrativeDomain must be called inside a <NarrativeDomainProvider>')
   }
   return ctx.narrativeDomain
+}
+
+export function useCampaignOps(): Pick<NarrativeDomainContextValue, 'listCampaigns' | 'loadCampaign'> {
+  const ctx = useContext(NarrativeDomainContext)
+  if (!ctx) {
+    throw new Error('useCampaignOps must be called inside a <NarrativeDomainProvider>')
+  }
+  return { listCampaigns: ctx.listCampaigns, loadCampaign: ctx.loadCampaign }
 }
 
 export function usePersistSetup(): (campaign: Campaign, character: CharacterState) => Promise<void> {

--- a/apps/web/src/providers/NarrativeDomainProvider.tsx
+++ b/apps/web/src/providers/NarrativeDomainProvider.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { NarrativeDomain, OracleService, DiceService, type INarrativeDomain } from '@saga-keeper/services'
+import { LocalAdapter } from '@saga-keeper/storage'
+import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
+import { OfflineAIGateway } from './OfflineAIGateway'
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+interface NarrativeDomainContextValue {
+  narrativeDomain: INarrativeDomain
+}
+
+const NarrativeDomainContext = createContext<NarrativeDomainContextValue | null>(null)
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+interface NarrativeDomainProviderProps {
+  children: ReactNode
+}
+
+/**
+ * Constructs the NarrativeDomain dependency graph once (via useMemo) and
+ * exposes it to the component tree via context.
+ *
+ * Architecture notes:
+ * - DiceService is a singleton object — NOT a class; do not call `new DiceService()`
+ * - OracleService takes `rand?: () => number` — constructed with no args (uses Math.random)
+ * - OfflineAIGateway.getTier() returns 'offline'; NarrativeDomain skips AI calls entirely
+ */
+export function NarrativeDomainProvider({ children }: NarrativeDomainProviderProps) {
+  const narrativeDomain = useMemo(() => {
+    const storage = new LocalAdapter()
+    const oracle = new OracleService()
+    const ai = new OfflineAIGateway()
+    // DiceService is a plain object (not a class) — pass the singleton directly
+    return new NarrativeDomain(storage, ironswornPlugin, ai, oracle, DiceService)
+  }, [])
+
+  return (
+    <NarrativeDomainContext.Provider value={{ narrativeDomain }}>
+      {children}
+    </NarrativeDomainContext.Provider>
+  )
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the INarrativeDomain instance from context.
+ * Must be called inside a NarrativeDomainProvider.
+ */
+export function useNarrativeDomain(): INarrativeDomain {
+  const ctx = useContext(NarrativeDomainContext)
+  if (!ctx) {
+    throw new Error('useNarrativeDomain must be called inside a <NarrativeDomainProvider>')
+  }
+  return ctx.narrativeDomain
+}

--- a/apps/web/src/providers/OfflineAIGateway.ts
+++ b/apps/web/src/providers/OfflineAIGateway.ts
@@ -1,0 +1,39 @@
+import type {
+  AIGateway,
+  AITier,
+  CompletionRequest,
+  CompletionResponse,
+  ProviderCapabilities,
+  StreamChunk,
+} from '@saga-keeper/domain'
+
+/**
+ * Stub AIGateway for the offline tier.
+ *
+ * NarrativeDomain checks getTier() === 'offline' and skips the AI call entirely,
+ * so complete() and stream() must never be called in normal operation.
+ * They throw to surface any accidental invocation during development.
+ */
+export class OfflineAIGateway implements AIGateway {
+  getTier(): AITier {
+    return 'offline'
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      streaming: false,
+      maxContextTokens: 0,
+      supportsSystemPrompt: false,
+      localOnly: true,
+    }
+  }
+
+  complete(_request: CompletionRequest): Promise<CompletionResponse> {
+    throw new Error('OfflineAIGateway.complete() must never be called in the offline tier')
+  }
+
+  // eslint-disable-next-line require-yield
+  async *stream(_request: CompletionRequest): AsyncGenerator<StreamChunk> {
+    throw new Error('OfflineAIGateway.stream() must never be called in the offline tier')
+  }
+}

--- a/apps/web/src/screens/forge/ForgeScreen.test.tsx
+++ b/apps/web/src/screens/forge/ForgeScreen.test.tsx
@@ -11,6 +11,10 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }))
 
+vi.mock('@/providers/NarrativeDomainProvider', () => ({
+  usePersistSetup: () => vi.fn().mockResolvedValue(undefined),
+}))
+
 // A draft that satisfies ironswornPlugin.creation.validate
 const VALID_DRAFT: ForgeDraft = {
   worldDescription: 'A harsh land of iron and stone.',

--- a/apps/web/src/screens/forge/ForgeScreen.tsx
+++ b/apps/web/src/screens/forge/ForgeScreen.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { ironswornPlugin, type IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
 import type { AIGateway, Campaign, CharacterState, CreationStep } from '@saga-keeper/domain'
 import { useGameStore } from '@/store'
+import { usePersistSetup } from '@/providers/NarrativeDomainProvider'
 import { INITIAL_DRAFT, type ForgeDraft, type StepProps } from './types'
 import { useForgeCounsel } from './hooks/useForgeCounsel'
 import { WorldSelectStep } from './steps/WorldSelectStep'
@@ -98,6 +99,8 @@ export function ForgeScreen({
   const totalSteps = steps.length
   const step = steps[Math.min(stepIndex, totalSteps - 1)]!
 
+  const persistSetup = usePersistSetup()
+
   useForgeCounsel(gateway, step, draft)
 
   // Move keyboard focus into the main content area whenever the step changes
@@ -161,6 +164,8 @@ export function ForgeScreen({
     useGameStore.getState().setCampaign(campaign)
     useGameStore.getState().setCharacter(character)
     navigate('/iron-sheet')
+    // Persist to IndexedDB in the background — completes before user can reach /skald
+    void persistSetup(campaign, character)
   }
 
   function handleNext() {

--- a/apps/web/src/screens/forge/ForgeScreen.tsx
+++ b/apps/web/src/screens/forge/ForgeScreen.tsx
@@ -165,7 +165,7 @@ export function ForgeScreen({
     useGameStore.getState().setCharacter(character)
     navigate('/iron-sheet')
     // Persist to IndexedDB in the background — completes before user can reach /skald
-    void persistSetup(campaign, character)
+    void persistSetup(campaign, character).catch(console.error)
   }
 
   function handleNext() {

--- a/apps/web/src/screens/forge/ForgeScreen.tsx
+++ b/apps/web/src/screens/forge/ForgeScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ironswornPlugin, type IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
-import type { AIGateway, CharacterState, CreationStep } from '@saga-keeper/domain'
+import type { AIGateway, Campaign, CharacterState, CreationStep } from '@saga-keeper/domain'
 import { useGameStore } from '@/store'
 import { INITIAL_DRAFT, type ForgeDraft, type StepProps } from './types'
 import { useForgeCounsel } from './hooks/useForgeCounsel'
@@ -148,6 +148,17 @@ export function ForgeScreen({
       createdAt: now,
       updatedAt: now,
     }
+    const campaign: Campaign = {
+      id: 'default',
+      name: draft.name,
+      rulesetId: 'ironsworn-v1',
+      status: 'active',
+      mode: 'solo',
+      characterIds: [character.id],
+      createdAt: now,
+      updatedAt: now,
+    }
+    useGameStore.getState().setCampaign(campaign)
     useGameStore.getState().setCharacter(character)
     navigate('/iron-sheet')
   }

--- a/apps/web/src/screens/forge/ForgeScreen.tsx
+++ b/apps/web/src/screens/forge/ForgeScreen.tsx
@@ -142,9 +142,10 @@ export function ForgeScreen({
       assetIds: draft.assetIds,
       vows: draft.vow ? [draft.vow] : [],
     }
+    const campaignId = globalThis.crypto.randomUUID()
     const character: CharacterState = {
       id: globalThis.crypto.randomUUID(),
-      campaignId: 'default',
+      campaignId,
       name: draft.name,
       rulesetId: 'ironsworn-v1',
       data: data as unknown as Record<string, unknown>,
@@ -152,7 +153,7 @@ export function ForgeScreen({
       updatedAt: now,
     }
     const campaign: Campaign = {
-      id: 'default',
+      id: campaignId,
       name: draft.name,
       rulesetId: 'ironsworn-v1',
       status: 'active',

--- a/apps/web/src/screens/great-hall/GreatHallScreen.module.css
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.module.css
@@ -1,0 +1,169 @@
+.screen {
+  display: grid;
+  grid-template-rows: 47px auto auto 1fr;
+  min-height: 100vh;
+  background: var(--color-void, #0d0b08);
+  color: var(--color-parchment, #c4a96e);
+  font-family: 'Cinzel', Georgia, serif;
+}
+
+/* ── HEADER ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 32px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.2);
+  background: rgba(30, 23, 16, 0.95);
+  backdrop-filter: blur(8px);
+}
+
+.logoBtn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.logoTitle {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 14px;
+  font-weight: 900;
+  color: var(--color-gold-bright, #f0b429);
+  letter-spacing: 3px;
+  text-transform: uppercase;
+}
+
+.headerNav {
+  display: flex;
+  gap: 2px;
+}
+
+.navBtn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-bone, #7a6a52);
+  padding: 6px 14px;
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s;
+  border-radius: 2px;
+  height: 47px;
+}
+
+.navBtn:hover,
+.navBtn[aria-current='page'] {
+  border-color: rgba(212, 148, 26, 0.4);
+  color: var(--color-gold, #d4941a);
+  background: rgba(212, 148, 26, 0.08);
+}
+
+.navBtn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* ── MAIN BODY ── */
+.main {
+  outline: none;
+}
+
+.body {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+  padding: 24px 28px;
+}
+
+@media (max-width: 768px) {
+  .body {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── CAMPAIGN COLUMN ── */
+.campCol {
+  /* section with aria-label="Campaigns" */
+}
+
+.campGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 960px) {
+  .campGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── RIGHT COLUMN ── */
+.rightCol {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── NEW CAMPAIGN CARD ── */
+.newCampCard {
+  border: 1px dashed rgba(42, 36, 28, 0.8);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 16px;
+  min-height: 180px;
+  text-align: center;
+}
+
+.newCampIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(212, 148, 26, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: var(--color-stone, #3d3428);
+  line-height: 40px;
+}
+
+.newCampLabel {
+  font-size: 9px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--color-stone, #3d3428);
+  margin: 0;
+}
+
+.newCampSub {
+  font-size: 9px;
+  color: rgba(42, 36, 28, 0.8);
+  font-style: italic;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.newCampBtn {
+  margin-top: 8px;
+  background: linear-gradient(135deg, rgba(139, 26, 26, 0.6), rgba(192, 57, 43, 0.4));
+  border: 1px solid rgba(192, 57, 43, 0.35);
+  border-radius: 3px;
+  padding: 7px 20px;
+  font-family: 'Cinzel', serif;
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: var(--color-parchment, #c4a96e);
+  cursor: pointer;
+  text-transform: uppercase;
+}

--- a/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { CampaignSummary, Campaign, CharacterState, SessionEvent } from '@saga-keeper/domain'
+import { GreatHallScreen } from './GreatHallScreen'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn()
+const mockListCampaigns = vi.fn<() => Promise<CampaignSummary[]>>()
+const mockLoadCampaign = vi.fn<
+  (id: string) => Promise<{ campaign: Campaign; character: CharacterState; events: SessionEvent[] }>
+>()
+const mockSetCampaign = vi.fn()
+const mockSetCharacter = vi.fn()
+const mockAppendEvent = vi.fn()
+const mockClearSession = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/great-hall' }),
+}))
+
+vi.mock('@/store', () => ({
+  useGameStore: vi.fn(),
+}))
+
+vi.mock('@/providers/NarrativeDomainProvider', () => ({
+  useCampaignOps: vi.fn(() => ({
+    listCampaigns: mockListCampaigns,
+    loadCampaign: mockLoadCampaign,
+  })),
+}))
+
+import { useGameStore } from '@/store'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSummary(overrides: Partial<CampaignSummary> = {}): CampaignSummary {
+  return {
+    id: 'c1',
+    name: 'The Ashwood Oath',
+    tagline: 'A blood-debt.',
+    rulesetId: 'ironsworn-v1',
+    status: 'active',
+    mode: 'solo',
+    characterIds: ['ch1'],
+    lastPlayedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function makeCampaign(): Campaign {
+  return {
+    id: 'c1',
+    name: 'The Ashwood Oath',
+    rulesetId: 'ironsworn-v1',
+    status: 'active',
+    mode: 'solo',
+    characterIds: ['ch1'],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function makeCharacter(): CharacterState {
+  return {
+    id: 'ch1',
+    campaignId: 'c1',
+    name: 'Björn',
+    rulesetId: 'ironsworn-v1',
+    data: { health: 5, spirit: 5, supply: 5, momentum: 2, vows: [], edge: 1, heart: 2, iron: 2, shadow: 1, wits: 1, debilities: {}, bonds: [], assetIds: [], experience: { earned: 0, spent: 0 }, tracks: { combat: 0, journey: 0, bonds: 0 } },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setupStore(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useGameStore).mockImplementation((selector: (s: any) => unknown) => {
+    const state = {
+      campaign: null,
+      character: null,
+      events: [],
+      turns: [],
+      setCampaign: mockSetCampaign,
+      setCharacter: mockSetCharacter,
+      appendEvent: mockAppendEvent,
+      clearSession: mockClearSession,
+      ...overrides,
+    }
+    return selector(state)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockNavigate.mockClear()
+  mockListCampaigns.mockResolvedValue([])
+  mockLoadCampaign.mockResolvedValue({ campaign: makeCampaign(), character: makeCharacter(), events: [] })
+  setupStore()
+})
+
+// ── Layout landmarks ──────────────────────────────────────────────────────────
+
+describe('GreatHallScreen — layout landmarks', () => {
+  it('renders exactly one banner landmark', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      const banners = document.querySelectorAll('[role="banner"]')
+      expect(banners.length).toBe(1)
+    })
+  })
+
+  it('renders a main landmark with tabIndex -1', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      const main = screen.getByRole('main')
+      expect(main).toBeTruthy()
+      expect(main.tabIndex).toBe(-1)
+    })
+  })
+
+  it('renders an h1 heading "The Great Hall"', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: /the great hall/i })).toBeTruthy()
+    })
+  })
+
+  it('renders a Campaign statistics region', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /campaign statistics/i })).toBeTruthy()
+    })
+  })
+
+  it('renders a Campaigns section', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /campaigns/i })).toBeTruthy()
+    })
+  })
+
+  it('renders Recent activity log', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('log', { name: /recent activity/i })).toBeTruthy()
+    })
+  })
+
+  it('renders Skald\'s Reminder section', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /skald's reminder/i })).toBeTruthy()
+    })
+  })
+
+  it('renders application navigation', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('navigation', { name: /application/i })).toBeTruthy()
+    })
+  })
+
+  it('HeroSection h1 is not wrapped in a banner landmark', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      const banners = document.querySelectorAll('[role="banner"]')
+      expect(banners.length).toBe(1)
+    })
+  })
+})
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+describe('GreatHallScreen — navigation', () => {
+  it('clicking the Saga Keeper logo calls navigate("/great-hall")', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /go to great hall/i }))
+    fireEvent.click(screen.getByRole('button', { name: /go to great hall/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
+  })
+
+  it('Iron Sheet nav button calls navigate("/iron-sheet")', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /iron sheet/i }))
+    fireEvent.click(screen.getByRole('button', { name: /iron sheet/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')
+  })
+
+  it('Oracle nav button calls navigate("/oracle")', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /^oracle$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^oracle$/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/oracle')
+  })
+
+  it('Skald nav button calls navigate("/skald")', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /skald/i }))
+    const nav = screen.getByRole('navigation', { name: /application/i })
+    const skaldBtn = nav.querySelector('button[data-navkey="skald"]') as HTMLButtonElement | null
+    // Find by accessible name within nav
+    const btns = Array.from(nav.querySelectorAll('button')) as HTMLButtonElement[]
+    const skald = btns.find((b) => /skald/i.test(b.textContent ?? ''))
+    expect(skald).toBeTruthy()
+    fireEvent.click(skald!)
+    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+  })
+
+  it('World Forge nav button is disabled', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /world forge/i }))
+    expect((screen.getByRole('button', { name: /world forge/i }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('Great Hall nav button is NOT in the nav (logo is the home entry)', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('navigation', { name: /application/i }))
+    const nav = screen.getByRole('navigation', { name: /application/i })
+    const btns = Array.from(nav.querySelectorAll('button'))
+    const greatHallNavBtn = btns.find((b) => /great hall/i.test(b.textContent ?? ''))
+    expect(greatHallNavBtn).toBeUndefined()
+  })
+})
+
+// ── Campaign list ─────────────────────────────────────────────────────────────
+
+describe('GreatHallScreen — campaign list', () => {
+  it('calls listCampaigns on mount', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => expect(mockListCampaigns).toHaveBeenCalledOnce())
+  })
+
+  it('renders a campaign card for each returned summary', async () => {
+    mockListCampaigns.mockResolvedValue([makeSummary(), makeSummary({ id: 'c2', name: 'Another Saga' })])
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByText('The Ashwood Oath')).toBeTruthy()
+      expect(screen.getByText('Another Saga')).toBeTruthy()
+    })
+  })
+
+  it('always renders the "Forge New Campaign" card', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /enter the forge/i })).toBeTruthy()
+    })
+  })
+
+  it('"Enter the Forge" button navigates to /forge', async () => {
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /enter the forge/i }))
+    fireEvent.click(screen.getByRole('button', { name: /enter the forge/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/forge')
+  })
+
+  it('stats bar shows correct campaign count', async () => {
+    mockListCampaigns.mockResolvedValue([makeSummary(), makeSummary({ id: 'c2', name: 'Another' })])
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-campaigns').textContent).toContain('2')
+    })
+  })
+
+  it('stats bar shows 0 campaigns when list is empty', async () => {
+    mockListCampaigns.mockResolvedValue([])
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-campaigns').textContent).toContain('0')
+    })
+  })
+})
+
+// ── Continue Saga ─────────────────────────────────────────────────────────────
+
+describe('GreatHallScreen — Continue Saga', () => {
+  it('clicking "Continue Saga" calls loadCampaign with the campaign id', async () => {
+    mockListCampaigns.mockResolvedValue([makeSummary()])
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /continue saga/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue saga/i }))
+    await waitFor(() => expect(mockLoadCampaign).toHaveBeenCalledWith('c1'))
+  })
+
+  it('clicking "Continue Saga" hydrates the store and navigates to /skald', async () => {
+    mockListCampaigns.mockResolvedValue([makeSummary()])
+    const campaign = makeCampaign()
+    const character = makeCharacter()
+    mockLoadCampaign.mockResolvedValue({ campaign, character, events: [] })
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /continue saga/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue saga/i }))
+    await waitFor(() => {
+      expect(mockClearSession).toHaveBeenCalled()
+      expect(mockSetCampaign).toHaveBeenCalledWith(campaign)
+      expect(mockSetCharacter).toHaveBeenCalledWith(character)
+      expect(mockNavigate).toHaveBeenCalledWith('/skald')
+    })
+  })
+
+  it('clicking "Continue Saga" appends events to the store', async () => {
+    const events: SessionEvent[] = [
+      { id: 'e1', campaignId: 'c1', turnId: 't1', type: 'move.resolved', playerId: 'p1', payload: {}, timestamp: new Date().toISOString() },
+    ]
+    mockListCampaigns.mockResolvedValue([makeSummary()])
+    mockLoadCampaign.mockResolvedValue({ campaign: makeCampaign(), character: makeCharacter(), events })
+    render(<GreatHallScreen />)
+    await waitFor(() => screen.getByRole('button', { name: /continue saga/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue saga/i }))
+    await waitFor(() => {
+      expect(mockAppendEvent).toHaveBeenCalledWith(events[0])
+    })
+  })
+})
+
+// ── Skald's Reminder ──────────────────────────────────────────────────────────
+
+describe('GreatHallScreen — Skald\'s Reminder', () => {
+  it('shows fallback text when no campaigns are loaded', async () => {
+    mockListCampaigns.mockResolvedValue([])
+    render(<GreatHallScreen />)
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /skald's reminder/i })).toBeTruthy()
+    })
+  })
+})

--- a/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
@@ -6,9 +6,10 @@ import { GreatHallScreen } from './GreatHallScreen'
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 const mockNavigate = vi.fn()
-const mockListCampaigns = vi.fn<() => Promise<CampaignSummary[]>>()
+const mockListCampaigns = vi.fn<[], Promise<CampaignSummary[]>>()
 const mockLoadCampaign = vi.fn<
-  (id: string) => Promise<{ campaign: Campaign; character: CharacterState; events: SessionEvent[] }>
+  [id: string],
+  Promise<{ campaign: Campaign; character: CharacterState; events: SessionEvent[] }>
 >()
 const mockSetCampaign = vi.fn()
 const mockSetCharacter = vi.fn()

--- a/apps/web/src/screens/great-hall/GreatHallScreen.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.tsx
@@ -58,8 +58,9 @@ export function GreatHallScreen() {
     campaigns[0]?.name ?? '',
   )
 
+  const firstCampaign = campaigns[0]
   const reminderText = deriveReminderText(
-    campaigns.length > 0 ? { id: campaigns[0].id, name: campaigns[0].name, rulesetId: campaigns[0].rulesetId, status: campaigns[0].status, mode: campaigns[0].mode, characterIds: campaigns[0].characterIds, createdAt: '', updatedAt: '' } : null,
+    firstCampaign ? { id: firstCampaign.id, name: firstCampaign.name, rulesetId: firstCampaign.rulesetId, status: firstCampaign.status, mode: firstCampaign.mode, characterIds: firstCampaign.characterIds, createdAt: '', updatedAt: '' } : null,
     character,
   )
 

--- a/apps/web/src/screens/great-hall/GreatHallScreen.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import type { CampaignSummary } from '@saga-keeper/domain'
+import type { IronswornCharacterData, IronswornVow } from '@saga-keeper/ruleset-ironsworn'
+import { useGameStore } from '@/store'
+import { useCampaignOps } from '@/providers/NarrativeDomainProvider'
+import { HeroSection } from './components/HeroSection/HeroSection'
+import { StatsBar } from './components/StatsBar/StatsBar'
+import { CampaignCard } from './components/CampaignCard/CampaignCard'
+import { ActivityFeed } from './components/ActivityFeed/ActivityFeed'
+import { SkaldReminderCard } from './components/SkaldReminderCard/SkaldReminderCard'
+import { sessionEventsToActivityItems } from './utils/sessionEventsToActivityItems'
+import { deriveReminderText } from './utils/deriveReminderText'
+import styles from './GreatHallScreen.module.css'
+
+const NAV_ITEMS = [
+  { label: 'Iron Sheet', path: '/iron-sheet' },
+  { label: 'Oracle', path: '/oracle' },
+  { label: 'Skald', path: '/skald' },
+  { label: 'World Forge', path: null },
+]
+
+export function GreatHallScreen() {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const { listCampaigns, loadCampaign } = useCampaignOps()
+
+  const [campaigns, setCampaigns] = useState<CampaignSummary[]>([])
+
+  const character = useGameStore((s) => s.character)
+  const events = useGameStore((s) => s.events)
+  const setCampaign = useGameStore((s) => s.setCampaign)
+  const setCharacter = useGameStore((s) => s.setCharacter)
+  const appendEvent = useGameStore((s) => s.appendEvent)
+  const clearSession = useGameStore((s) => s.clearSession)
+
+  useEffect(() => {
+    listCampaigns().then(setCampaigns).catch(() => {})
+  }, [listCampaigns])
+
+  async function handleContinue(campaignId: string) {
+    const { campaign, character: loadedChar, events: loadedEvents } = await loadCampaign(campaignId)
+    clearSession()
+    setCampaign(campaign)
+    setCharacter(loadedChar)
+    for (const event of loadedEvents) {
+      appendEvent(event)
+    }
+    navigate('/skald')
+  }
+
+  // Derived data
+  const data = character ? (character.data as unknown as IronswornCharacterData) : null
+  const leadingVow: IronswornVow | null = data?.vows?.find((v) => !v.fulfilled) ?? data?.vows?.[0] ?? null
+
+  const activityItems = sessionEventsToActivityItems(
+    events,
+    campaigns[0]?.name ?? '',
+  )
+
+  const reminderText = deriveReminderText(
+    campaigns.length > 0 ? { id: campaigns[0].id, name: campaigns[0].name, rulesetId: campaigns[0].rulesetId, status: campaigns[0].status, mode: campaigns[0].mode, characterIds: campaigns[0].characterIds, createdAt: '', updatedAt: '' } : null,
+    character,
+  )
+
+  const totalCharacters = campaigns.reduce((n, c) => n + c.characterIds.length, 0)
+
+  return (
+    <div className={styles.screen}>
+      <header className={styles.header} role="banner">
+        <button
+          type="button"
+          className={styles.logoBtn}
+          aria-label="Go to Great Hall"
+          aria-current={pathname === '/great-hall' ? 'page' : undefined}
+          onClick={() => navigate('/great-hall')}
+        >
+          <span className={styles.logoTitle}>Saga Keeper</span>
+        </button>
+        <nav className={styles.headerNav} aria-label="Application">
+          {NAV_ITEMS.map(({ label, path }) => (
+            <button
+              key={label}
+              type="button"
+              className={styles.navBtn}
+              aria-current={path === pathname ? 'page' : undefined}
+              disabled={path === null}
+              onClick={path ? () => navigate(path) : undefined}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <HeroSection />
+
+      <StatsBar
+        campaigns={campaigns.length}
+        characters={totalCharacters}
+        vowsSworn={0}
+        vowsFulfilled={0}
+        sessionsPlayed={0}
+      />
+
+      <main className={styles.main} role="main" tabIndex={-1}>
+        <div className={styles.body}>
+          <section className={styles.campCol} role="region" aria-label="Campaigns">
+            <div className={styles.campGrid}>
+              {campaigns.map((c) => (
+                <CampaignCard
+                  key={c.id}
+                  campaign={c}
+                  character={
+                    character && campaigns.find((camp) => camp.characterIds.includes(character.id))?.id === c.id
+                      ? {
+                          name: character.name,
+                          health: data?.health ?? 5,
+                          spirit: data?.spirit ?? 5,
+                          momentum: data?.momentum ?? 2,
+                        }
+                      : null
+                  }
+                  leadingVow={
+                    leadingVow
+                      ? { title: leadingVow.title, progress: leadingVow.progress }
+                      : null
+                  }
+                  onContinue={() => handleContinue(c.id)}
+                  onDetails={() => {}}
+                />
+              ))}
+              <NewCampaignCard onForge={() => navigate('/forge')} />
+            </div>
+          </section>
+
+          <div className={styles.rightCol}>
+            <ActivityFeed items={activityItems} />
+            <SkaldReminderCard reminderText={reminderText} />
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+// ── New Campaign Card (inline — single use, no logic) ─────────────────────────
+
+interface NewCampaignCardProps {
+  onForge: () => void
+}
+
+function NewCampaignCard({ onForge }: NewCampaignCardProps) {
+  return (
+    <div className={styles.newCampCard}>
+      <span className={styles.newCampIcon} aria-hidden="true">+</span>
+      <p className={styles.newCampLabel}>Forge New Campaign</p>
+      <p className={styles.newCampSub}>
+        Begin a new saga. Name your world, create your character, and swear your first iron vow.
+      </p>
+      <button type="button" className={styles.newCampBtn} onClick={onForge} aria-label="Enter the Forge">
+        Enter the Forge
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/screens/great-hall/components/ActivityFeed/ActivityFeed.module.css
+++ b/apps/web/src/screens/great-hall/components/ActivityFeed/ActivityFeed.module.css
@@ -1,0 +1,66 @@
+.feed {
+  display: flex;
+  flex-direction: column;
+}
+
+.empty {
+  font-size: 10px;
+  color: var(--color-stone, #3d3428);
+  font-style: italic;
+  padding: 12px 0;
+}
+
+.item {
+  padding: 9px 0;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.08);
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+
+.dot[data-dot-color='gold'] {
+  background: var(--color-gold, #d4941a);
+}
+
+.dot[data-dot-color='blue'] {
+  background: var(--color-ice, #7ab3cc);
+}
+
+.dot[data-dot-color='red'] {
+  background: var(--color-blood, #c0392b);
+}
+
+.dot[data-dot-color='dim'] {
+  background: rgba(42, 36, 28, 0.8);
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.title {
+  font-size: 10px;
+  color: var(--color-bone, #7a6a52);
+  line-height: 1.4;
+  margin: 0 0 2px;
+}
+
+.meta {
+  font-size: 8px;
+  color: var(--color-stone, #3d3428);
+  letter-spacing: 1px;
+  margin: 0;
+}

--- a/apps/web/src/screens/great-hall/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/apps/web/src/screens/great-hall/components/ActivityFeed/ActivityFeed.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ActivityFeed } from './ActivityFeed'
+import type { ActivityItem } from './ActivityFeed'
+
+const items: ActivityItem[] = [
+  { id: '1', title: 'Björn compelled Elder Halvard — Weak Hit', meta: 'The Ashwood Oath · Today', dotColor: 'gold' },
+  { id: '2', title: 'Leif took 2 harm — Wounded debility applied', meta: 'Frozen Shore · Yesterday', dotColor: 'red' },
+  { id: '3', title: 'Oracle consulted — Yes, but...', meta: 'The Ashwood Oath · Today', dotColor: 'gold' },
+]
+
+describe('ActivityFeed', () => {
+  it('renders a log region with aria-label "Recent activity"', () => {
+    render(<ActivityFeed items={items} />)
+    expect(screen.getByRole('log', { name: /recent activity/i })).toBeTruthy()
+  })
+
+  it('renders one list item per activity item', () => {
+    render(<ActivityFeed items={items} />)
+    const log = screen.getByRole('log', { name: /recent activity/i })
+    expect(log.querySelectorAll('[data-activity-item]').length).toBe(3)
+  })
+
+  it('renders item title text', () => {
+    render(<ActivityFeed items={items} />)
+    expect(screen.getByText(/Björn compelled/i)).toBeTruthy()
+  })
+
+  it('renders item meta text', () => {
+    render(<ActivityFeed items={items} />)
+    expect(screen.getByText(/Frozen Shore/i)).toBeTruthy()
+  })
+
+  it('sets data-color attribute on dot for each item', () => {
+    render(<ActivityFeed items={items} />)
+    const log = screen.getByRole('log', { name: /recent activity/i })
+    const goldDots = log.querySelectorAll('[data-dot-color="gold"]')
+    expect(goldDots.length).toBe(2)
+    const redDots = log.querySelectorAll('[data-dot-color="red"]')
+    expect(redDots.length).toBe(1)
+  })
+
+  it('renders "No recent activity" when items is empty', () => {
+    render(<ActivityFeed items={[]} />)
+    expect(screen.getByText(/no recent activity/i)).toBeTruthy()
+  })
+
+  it('does not render the empty-state message when items are present', () => {
+    render(<ActivityFeed items={items} />)
+    expect(screen.queryByText(/no recent activity/i)).toBeNull()
+  })
+})

--- a/apps/web/src/screens/great-hall/components/ActivityFeed/ActivityFeed.tsx
+++ b/apps/web/src/screens/great-hall/components/ActivityFeed/ActivityFeed.tsx
@@ -1,0 +1,33 @@
+import type { ActivityDotColor } from '../../utils/sessionEventsToActivityItems'
+import styles from './ActivityFeed.module.css'
+
+export interface ActivityItem {
+  id: string
+  title: string
+  meta: string
+  dotColor: ActivityDotColor
+}
+
+export interface ActivityFeedProps {
+  items: ActivityItem[]
+}
+
+export function ActivityFeed({ items }: ActivityFeedProps) {
+  return (
+    <div role="log" aria-label="Recent activity" aria-live="polite" className={styles.feed}>
+      {items.length === 0 ? (
+        <p className={styles.empty}>No recent activity</p>
+      ) : (
+        items.map((item) => (
+          <div key={item.id} className={styles.item} data-activity-item>
+            <span className={styles.dot} data-dot-color={item.dotColor} aria-hidden="true" />
+            <div className={styles.body}>
+              <p className={styles.title}>{item.title}</p>
+              <p className={styles.meta}>{item.meta}</p>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.module.css
+++ b/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.module.css
@@ -1,0 +1,194 @@
+.card {
+  background: var(--color-ash, #13100d);
+  border: 1px solid rgba(212, 148, 26, 0.15);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+}
+
+.card[data-status='active']::before {
+  background: linear-gradient(90deg, transparent, var(--color-gold, #d4941a) 40%, transparent);
+}
+
+.card[data-status='complete']::before {
+  background: linear-gradient(90deg, transparent, rgba(122, 179, 204, 0.5) 40%, transparent);
+}
+
+.card[data-status='abandoned']::before {
+  background: linear-gradient(90deg, transparent, rgba(60, 50, 40, 0.5) 40%, transparent);
+}
+
+.inner {
+  padding: 14px 16px;
+  flex: 1;
+}
+
+.statusRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.statusBadge {
+  font-size: 7px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 2px;
+}
+
+.statusBadge[data-status='active'] {
+  background: rgba(212, 148, 26, 0.1);
+  border: 1px solid rgba(212, 148, 26, 0.3);
+  color: var(--color-gold, #d4941a);
+}
+
+.statusBadge[data-status='complete'] {
+  background: rgba(122, 179, 204, 0.08);
+  border: 1px solid rgba(122, 179, 204, 0.25);
+  color: var(--color-ice, #7ab3cc);
+}
+
+.statusBadge[data-status='abandoned'] {
+  background: rgba(60, 50, 40, 0.3);
+  border: 1px solid rgba(80, 65, 50, 0.4);
+  color: var(--color-bone, #7a6a52);
+}
+
+.lastPlayed {
+  font-size: 8px;
+  color: var(--color-stone, #3d3428);
+  letter-spacing: 1px;
+}
+
+.name {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 15px;
+  color: var(--color-gold-bright, #f0b429);
+  margin: 0 0 4px;
+  line-height: 1.2;
+}
+
+.tagline {
+  font-size: 10px;
+  color: var(--color-bone, #7a6a52);
+  font-style: italic;
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.character {
+  margin-bottom: 10px;
+}
+
+.charName {
+  font-size: 9px;
+  color: var(--color-parchment, #c4a96e);
+  letter-spacing: 1px;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.meters {
+  display: flex;
+  gap: 4px;
+}
+
+.meter {
+  flex: 1;
+  height: 3px;
+}
+
+.vow {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(139, 26, 26, 0.15);
+  border-radius: 2px;
+  padding: 6px 8px;
+  margin-bottom: 4px;
+}
+
+.vowTitle {
+  font-size: 9px;
+  color: var(--color-bone, #7a6a52);
+  font-style: italic;
+  margin: 0 0 4px;
+  line-height: 1.4;
+}
+
+.pips {
+  display: flex;
+  gap: 2px;
+}
+
+.pip {
+  flex: 1;
+  height: 5px;
+  border-radius: 1px;
+  border: 1px solid rgba(139, 26, 26, 0.15);
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.pip[data-pip='filled'] {
+  background: rgba(139, 26, 26, 0.5);
+  border-color: rgba(192, 57, 43, 0.3);
+}
+
+.footer {
+  padding: 10px 16px;
+  border-top: 1px solid rgba(212, 148, 26, 0.1);
+  display: flex;
+  gap: 6px;
+}
+
+.continueBtn {
+  flex: 1;
+  padding: 7px;
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  border-radius: 3px;
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(139, 26, 26, 0.7), rgba(192, 57, 43, 0.5));
+  border: 1px solid rgba(192, 57, 43, 0.4);
+  color: var(--color-parchment, #c4a96e);
+}
+
+.viewBtn {
+  flex: 1;
+  padding: 7px;
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  border-radius: 3px;
+  cursor: pointer;
+  background: rgba(30, 23, 16, 0.8);
+  border: 1px solid rgba(212, 148, 26, 0.2);
+  color: var(--color-bone, #7a6a52);
+}
+
+.detailsBtn {
+  padding: 7px 12px;
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  border-radius: 3px;
+  cursor: pointer;
+  background: rgba(30, 23, 16, 0.5);
+  border: 1px solid rgba(42, 36, 28, 0.8);
+  color: var(--color-stone, #3d3428);
+}

--- a/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.test.tsx
+++ b/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { CampaignSummary } from '@saga-keeper/domain'
+import { CampaignCard } from './CampaignCard'
+
+function makeCampaign(overrides: Partial<CampaignSummary> = {}): CampaignSummary {
+  return {
+    id: 'c1',
+    name: 'The Ashwood Oath',
+    tagline: 'A blood-debt and a warlord who will not rest.',
+    rulesetId: 'ironsworn-v1',
+    status: 'active',
+    mode: 'solo',
+    characterIds: ['ch1'],
+    lastPlayedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+const defaultCharacter = { name: 'Björn Ashclaw', health: 4, spirit: 3, momentum: 2 }
+const defaultVow = { title: 'Avenge the slaughter of Clan Thornwood', progress: 3 }
+
+describe('CampaignCard — basic info', () => {
+  it('renders campaign name', () => {
+    render(<CampaignCard campaign={makeCampaign()} character={defaultCharacter} leadingVow={defaultVow} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText('The Ashwood Oath')).toBeTruthy()
+  })
+
+  it('renders campaign tagline', () => {
+    render(<CampaignCard campaign={makeCampaign()} character={defaultCharacter} leadingVow={defaultVow} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText(/blood-debt/i)).toBeTruthy()
+  })
+
+  it('does not render tagline when absent', () => {
+    const { container } = render(<CampaignCard campaign={makeCampaign({ tagline: undefined })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(container.querySelector('[data-tagline]')).toBeNull()
+  })
+
+  it('renders "Today" for lastPlayedAt set to now', () => {
+    render(<CampaignCard campaign={makeCampaign({ lastPlayedAt: new Date().toISOString() })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText('Today')).toBeTruthy()
+  })
+})
+
+describe('CampaignCard — status badge', () => {
+  it('renders "Active" badge for active status', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'active' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText('Active')).toBeTruthy()
+  })
+
+  it('renders "Saga Complete" badge for complete status', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'complete' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText('Saga Complete')).toBeTruthy()
+  })
+
+  it('renders "Abandoned" badge for abandoned status', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'abandoned' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText('Abandoned')).toBeTruthy()
+  })
+
+  it('appends "· Co-op" for coop-same-pc mode', () => {
+    render(<CampaignCard campaign={makeCampaign({ mode: 'coop-same-pc' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText(/Active.*Co-op/i)).toBeTruthy()
+  })
+
+  it('appends "· Co-op" for coop-remote mode', () => {
+    render(<CampaignCard campaign={makeCampaign({ mode: 'coop-remote' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText(/Active.*Co-op/i)).toBeTruthy()
+  })
+})
+
+describe('CampaignCard — buttons', () => {
+  it('renders "Continue Saga" button for active campaigns', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'active' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /continue saga/i })).toBeTruthy()
+  })
+
+  it('does not render "Continue Saga" for complete campaigns', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'complete' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /continue saga/i })).toBeNull()
+  })
+
+  it('does not render "Continue Saga" for abandoned campaigns', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'abandoned' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /continue saga/i })).toBeNull()
+  })
+
+  it('clicking "Continue Saga" calls onContinue', () => {
+    const onContinue = vi.fn()
+    render(<CampaignCard campaign={makeCampaign({ status: 'active' })} character={null} leadingVow={null} onContinue={onContinue} onDetails={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /continue saga/i }))
+    expect(onContinue).toHaveBeenCalledOnce()
+  })
+
+  it('renders "View Chronicle" button for complete campaigns', () => {
+    render(<CampaignCard campaign={makeCampaign({ status: 'complete' })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /view chronicle/i })).toBeTruthy()
+  })
+
+  it('clicking "Details" calls onDetails', () => {
+    const onDetails = vi.fn()
+    render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={onDetails} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(onDetails).toHaveBeenCalledOnce()
+  })
+})
+
+describe('CampaignCard — character', () => {
+  it('renders character name', () => {
+    render(<CampaignCard campaign={makeCampaign()} character={defaultCharacter} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText('Björn Ashclaw')).toBeTruthy()
+  })
+
+  it('renders three meter elements with aria-labels', () => {
+    render(<CampaignCard campaign={makeCampaign()} character={defaultCharacter} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByRole('meter', { name: /health/i })).toBeTruthy()
+    expect(screen.getByRole('meter', { name: /spirit/i })).toBeTruthy()
+    expect(screen.getByRole('meter', { name: /momentum/i })).toBeTruthy()
+  })
+
+  it('sets correct aria-valuenow on meters', () => {
+    render(<CampaignCard campaign={makeCampaign()} character={defaultCharacter} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    const healthMeter = screen.getByRole('meter', { name: /health/i })
+    expect(healthMeter.getAttribute('aria-valuenow')).toBe('4')
+  })
+
+  it('does not render character section when character is null', () => {
+    const { container } = render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(container.querySelector('[data-character]')).toBeNull()
+  })
+})
+
+describe('CampaignCard — vow progress', () => {
+  it('renders vow title', () => {
+    render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={defaultVow} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(screen.getByText(/Avenge the slaughter/i)).toBeTruthy()
+  })
+
+  it('renders exactly 10 progress pips', () => {
+    const { container } = render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={defaultVow} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(container.querySelectorAll('[data-pip]').length).toBe(10)
+  })
+
+  it('marks correct number of pips as filled', () => {
+    const { container } = render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={{ title: 'Test', progress: 4 }} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(container.querySelectorAll('[data-pip="filled"]').length).toBe(4)
+  })
+
+  it('marks remaining pips as empty', () => {
+    const { container } = render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={{ title: 'Test', progress: 4 }} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(container.querySelectorAll('[data-pip="empty"]').length).toBe(6)
+  })
+
+  it('does not render vow section when leadingVow is null', () => {
+    const { container } = render(<CampaignCard campaign={makeCampaign()} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    expect(container.querySelector('[data-vow]')).toBeNull()
+  })
+})

--- a/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.test.tsx
+++ b/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.test.tsx
@@ -32,7 +32,8 @@ describe('CampaignCard — basic info', () => {
   })
 
   it('does not render tagline when absent', () => {
-    const { container } = render(<CampaignCard campaign={makeCampaign({ tagline: undefined })} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
+    const { tagline: _tag, ...campaignNoTagline } = makeCampaign()
+    const { container } = render(<CampaignCard campaign={campaignNoTagline as CampaignSummary} character={null} leadingVow={null} onContinue={vi.fn()} onDetails={vi.fn()} />)
     expect(container.querySelector('[data-tagline]')).toBeNull()
   })
 

--- a/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.tsx
+++ b/apps/web/src/screens/great-hall/components/CampaignCard/CampaignCard.tsx
@@ -1,0 +1,133 @@
+import type { CampaignSummary } from '@saga-keeper/domain'
+import { formatRelativeDate } from '../../utils/formatRelativeDate'
+import styles from './CampaignCard.module.css'
+
+interface CampaignCardCharacter {
+  name: string
+  health: number
+  spirit: number
+  momentum: number
+}
+
+interface CampaignCardVow {
+  title: string
+  progress: number
+}
+
+export interface CampaignCardProps {
+  campaign: CampaignSummary
+  character: CampaignCardCharacter | null
+  leadingVow: CampaignCardVow | null
+  onContinue: () => void
+  onDetails: () => void
+}
+
+function statusLabel(campaign: CampaignSummary): string {
+  const base =
+    campaign.status === 'active'
+      ? 'Active'
+      : campaign.status === 'complete'
+        ? 'Saga Complete'
+        : 'Abandoned'
+  const isCoOp = campaign.mode === 'coop-same-pc' || campaign.mode === 'coop-remote'
+  return isCoOp && campaign.status === 'active' ? `${base} · Co-op` : base
+}
+
+export function CampaignCard({ campaign, character, leadingVow, onContinue, onDetails }: CampaignCardProps) {
+  const isActive = campaign.status === 'active'
+  const isComplete = campaign.status === 'complete'
+
+  return (
+    <article className={styles.card} data-status={campaign.status}>
+      <div className={styles.inner}>
+        <div className={styles.statusRow}>
+          <span className={styles.statusBadge} data-status={campaign.status}>
+            {statusLabel(campaign)}
+          </span>
+          {campaign.lastPlayedAt && (
+            <span className={styles.lastPlayed}>{formatRelativeDate(campaign.lastPlayedAt)}</span>
+          )}
+        </div>
+
+        <h2 className={styles.name}>{campaign.name}</h2>
+
+        {campaign.tagline && (
+          <p className={styles.tagline} data-tagline>
+            {campaign.tagline}
+          </p>
+        )}
+
+        {character && (
+          <div className={styles.character} data-character>
+            <span className={styles.charName}>{character.name}</span>
+            <div className={styles.meters}>
+              <meter
+                className={styles.meter}
+                aria-label="Health"
+                value={character.health}
+                min={0}
+                max={5}
+                aria-valuenow={character.health}
+                aria-valuemin={0}
+                aria-valuemax={5}
+              />
+              <meter
+                className={styles.meter}
+                aria-label="Spirit"
+                value={character.spirit}
+                min={0}
+                max={5}
+                aria-valuenow={character.spirit}
+                aria-valuemin={0}
+                aria-valuemax={5}
+              />
+              <meter
+                className={styles.meter}
+                aria-label="Momentum"
+                value={character.momentum}
+                min={-6}
+                max={10}
+                aria-valuenow={character.momentum}
+                aria-valuemin={-6}
+                aria-valuemax={10}
+              />
+            </div>
+          </div>
+        )}
+
+        {leadingVow && (
+          <div className={styles.vow} data-vow>
+            <p className={styles.vowTitle}>{leadingVow.title}</p>
+            <div className={styles.pips} role="img" aria-label={`Vow progress: ${leadingVow.progress} of 10`}>
+              {Array.from({ length: 10 }, (_, i) => (
+                <span
+                  key={i}
+                  className={styles.pip}
+                  data-pip={i < leadingVow.progress ? 'filled' : 'empty'}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        {isActive && (
+          <button type="button" className={styles.continueBtn} onClick={onContinue}>
+            Continue Saga
+          </button>
+        )}
+        {isComplete && (
+          <button type="button" className={styles.viewBtn} onClick={onDetails}>
+            View Chronicle
+          </button>
+        )}
+        {!isComplete && (
+          <button type="button" className={styles.detailsBtn} onClick={onDetails}>
+            Details
+          </button>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/screens/great-hall/components/HeroSection/HeroSection.module.css
+++ b/apps/web/src/screens/great-hall/components/HeroSection/HeroSection.module.css
@@ -1,0 +1,59 @@
+.hero {
+  padding: 36px 28px 28px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--color-gold, #d4941a) 30%, var(--color-blood, #8b1a1a) 60%, var(--color-gold, #d4941a) 80%, transparent);
+}
+
+.rune {
+  position: absolute;
+  right: 28px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.06;
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 120px;
+  color: var(--color-gold, #d4941a);
+  pointer-events: none;
+  line-height: 1;
+  user-select: none;
+}
+
+.inner {
+  max-width: 520px;
+}
+
+.greeting {
+  font-size: 9px;
+  letter-spacing: 5px;
+  color: var(--color-stone, #3d3428);
+  text-transform: uppercase;
+  margin: 0 0 8px;
+}
+
+.headline {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 28px;
+  color: var(--color-gold-bright, #f0b429);
+  letter-spacing: 1px;
+  line-height: 1.2;
+  margin: 0 0 10px;
+}
+
+.tagline {
+  font-size: 12px;
+  color: var(--color-bone, #7a6a52);
+  font-style: italic;
+  line-height: 1.7;
+  margin: 0;
+}

--- a/apps/web/src/screens/great-hall/components/HeroSection/HeroSection.test.tsx
+++ b/apps/web/src/screens/great-hall/components/HeroSection/HeroSection.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HeroSection } from './HeroSection'
+
+describe('HeroSection', () => {
+  it('renders as a div or section — NOT role="banner"', () => {
+    render(<HeroSection />)
+    // There should be no banner role on this element (the outer <header> owns that)
+    // We verify by checking the element renders without a banner landmark
+    const banners = document.querySelectorAll('[role="banner"]')
+    expect(banners.length).toBe(0)
+  })
+
+  it('renders an h1 heading "The Great Hall"', () => {
+    render(<HeroSection />)
+    expect(screen.getByRole('heading', { level: 1, name: /the great hall/i })).toBeTruthy()
+  })
+
+  it('renders a greeting text', () => {
+    render(<HeroSection />)
+    expect(screen.getByText(/welcome/i)).toBeTruthy()
+  })
+
+  it('renders a tagline/subtitle', () => {
+    render(<HeroSection />)
+    expect(screen.getByText(/saga/i)).toBeTruthy()
+  })
+
+  it('renders the decorative rune aria-hidden', () => {
+    const { container } = render(<HeroSection />)
+    const rune = container.querySelector('[aria-hidden="true"]')
+    expect(rune).toBeTruthy()
+    expect(rune!.textContent).toContain('ᚺ')
+  })
+})

--- a/apps/web/src/screens/great-hall/components/HeroSection/HeroSection.tsx
+++ b/apps/web/src/screens/great-hall/components/HeroSection/HeroSection.tsx
@@ -1,0 +1,16 @@
+import styles from './HeroSection.module.css'
+
+export function HeroSection() {
+  return (
+    <div className={styles.hero}>
+      <span className={styles.rune} aria-hidden="true">ᚺ</span>
+      <div className={styles.inner}>
+        <p className={styles.greeting}>Welcome back, Skald</p>
+        <h1 className={styles.headline}>The Great Hall</h1>
+        <p className={styles.tagline}>
+          Your sagas endure here. Choose a campaign to continue your oath — or forge a new one from blood and iron.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/great-hall/components/SkaldReminderCard/SkaldReminderCard.module.css
+++ b/apps/web/src/screens/great-hall/components/SkaldReminderCard/SkaldReminderCard.module.css
@@ -1,0 +1,22 @@
+.card {
+  background: var(--color-ash, #13100d);
+  border: 1px solid rgba(212, 148, 26, 0.12);
+  border-radius: 3px;
+  padding: 10px 12px;
+}
+
+.label {
+  font-size: 7px;
+  letter-spacing: 3px;
+  color: var(--color-stone, #3d3428);
+  text-transform: uppercase;
+  margin: 0 0 6px;
+}
+
+.text {
+  font-size: 9px;
+  color: var(--color-bone, #7a6a52);
+  font-style: italic;
+  line-height: 1.6;
+  margin: 0;
+}

--- a/apps/web/src/screens/great-hall/components/SkaldReminderCard/SkaldReminderCard.test.tsx
+++ b/apps/web/src/screens/great-hall/components/SkaldReminderCard/SkaldReminderCard.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SkaldReminderCard } from './SkaldReminderCard'
+
+describe('SkaldReminderCard', () => {
+  it('renders a section with aria-label "Skald\'s Reminder"', () => {
+    render(<SkaldReminderCard reminderText={null} />)
+    expect(screen.getByRole('region', { name: /skald's reminder/i })).toBeTruthy()
+  })
+
+  it('renders the label text "Skald\'s Reminder"', () => {
+    render(<SkaldReminderCard reminderText={null} />)
+    expect(screen.getByText(/skald's reminder/i)).toBeTruthy()
+  })
+
+  it('renders the provided reminderText', () => {
+    render(<SkaldReminderCard reminderText="Your character is in a dire state." />)
+    expect(screen.getByText(/dire state/i)).toBeTruthy()
+  })
+
+  it('renders fallback text when reminderText is null', () => {
+    render(<SkaldReminderCard reminderText={null} />)
+    expect(screen.getByText(/begin a new saga/i)).toBeTruthy()
+  })
+
+  it('does not render fallback when reminderText is provided', () => {
+    render(<SkaldReminderCard reminderText="Your saga continues." />)
+    expect(screen.queryByText(/begin a new saga/i)).toBeNull()
+  })
+})

--- a/apps/web/src/screens/great-hall/components/SkaldReminderCard/SkaldReminderCard.tsx
+++ b/apps/web/src/screens/great-hall/components/SkaldReminderCard/SkaldReminderCard.tsx
@@ -1,0 +1,16 @@
+import styles from './SkaldReminderCard.module.css'
+
+export interface SkaldReminderCardProps {
+  reminderText: string | null
+}
+
+const FALLBACK = 'Begin a new saga to receive counsel from the Skald.'
+
+export function SkaldReminderCard({ reminderText }: SkaldReminderCardProps) {
+  return (
+    <section role="region" aria-label="Skald's Reminder" className={styles.card}>
+      <p className={styles.label}>Skald's Reminder</p>
+      <p className={styles.text}>{reminderText ?? FALLBACK}</p>
+    </section>
+  )
+}

--- a/apps/web/src/screens/great-hall/components/StatsBar/StatsBar.module.css
+++ b/apps/web/src/screens/great-hall/components/StatsBar/StatsBar.module.css
@@ -1,0 +1,33 @@
+.statsBar {
+  display: flex;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.12);
+}
+
+.stat {
+  flex: 1;
+  padding: 14px 20px;
+  border-right: 1px solid rgba(212, 148, 26, 0.12);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.stat:last-child {
+  border-right: none;
+}
+
+.statVal {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 22px;
+  color: var(--color-gold, #d4941a);
+  line-height: 1;
+}
+
+.statLabel {
+  font-size: 8px;
+  letter-spacing: 3px;
+  color: var(--color-stone, #3d3428);
+  text-transform: uppercase;
+}

--- a/apps/web/src/screens/great-hall/components/StatsBar/StatsBar.test.tsx
+++ b/apps/web/src/screens/great-hall/components/StatsBar/StatsBar.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatsBar } from './StatsBar'
+
+const defaultProps = {
+  campaigns: 3,
+  characters: 4,
+  vowsSworn: 12,
+  vowsFulfilled: 7,
+  sessionsPlayed: 34,
+}
+
+describe('StatsBar', () => {
+  it('renders a region with aria-label "Campaign statistics"', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByRole('region', { name: /campaign statistics/i })).toBeTruthy()
+  })
+
+  it('renders exactly 5 stat blocks', () => {
+    render(<StatsBar {...defaultProps} />)
+    const region = screen.getByRole('region', { name: /campaign statistics/i })
+    expect(region.querySelectorAll('[data-stat]').length).toBe(5)
+  })
+
+  it('renders all five labels', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByText(/campaigns/i)).toBeTruthy()
+    expect(screen.getByText(/characters/i)).toBeTruthy()
+    expect(screen.getByText(/vows sworn/i)).toBeTruthy()
+    expect(screen.getByText(/vows fulfilled/i)).toBeTruthy()
+    expect(screen.getByText(/sessions played/i)).toBeTruthy()
+  })
+
+  it('renders the numeric value for campaigns', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByTestId('stat-campaigns').textContent).toContain('3')
+  })
+
+  it('renders the numeric value for characters', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByTestId('stat-characters').textContent).toContain('4')
+  })
+
+  it('renders the numeric value for vowsSworn', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByTestId('stat-vows-sworn').textContent).toContain('12')
+  })
+
+  it('renders the numeric value for vowsFulfilled', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByTestId('stat-vows-fulfilled').textContent).toContain('7')
+  })
+
+  it('renders the numeric value for sessionsPlayed', () => {
+    render(<StatsBar {...defaultProps} />)
+    expect(screen.getByTestId('stat-sessions-played').textContent).toContain('34')
+  })
+
+  it('renders zero values correctly', () => {
+    render(<StatsBar campaigns={0} characters={0} vowsSworn={0} vowsFulfilled={0} sessionsPlayed={0} />)
+    const region = screen.getByRole('region', { name: /campaign statistics/i })
+    const zeros = Array.from(region.querySelectorAll('[data-stat-val]')).filter(
+      (el) => el.textContent === '0',
+    )
+    expect(zeros.length).toBe(5)
+  })
+})

--- a/apps/web/src/screens/great-hall/components/StatsBar/StatsBar.tsx
+++ b/apps/web/src/screens/great-hall/components/StatsBar/StatsBar.tsx
@@ -1,0 +1,32 @@
+import styles from './StatsBar.module.css'
+
+export interface StatsBarProps {
+  campaigns: number
+  characters: number
+  vowsSworn: number
+  vowsFulfilled: number
+  sessionsPlayed: number
+}
+
+const STATS = [
+  { key: 'campaigns', label: 'Campaigns', testId: 'stat-campaigns' },
+  { key: 'characters', label: 'Characters', testId: 'stat-characters' },
+  { key: 'vowsSworn', label: 'Vows Sworn', testId: 'stat-vows-sworn' },
+  { key: 'vowsFulfilled', label: 'Vows Fulfilled', testId: 'stat-vows-fulfilled' },
+  { key: 'sessionsPlayed', label: 'Sessions Played', testId: 'stat-sessions-played' },
+] as const
+
+export function StatsBar({ campaigns, characters, vowsSworn, vowsFulfilled, sessionsPlayed }: StatsBarProps) {
+  const values: Record<string, number> = { campaigns, characters, vowsSworn, vowsFulfilled, sessionsPlayed }
+
+  return (
+    <div role="region" aria-label="Campaign statistics" className={styles.statsBar}>
+      {STATS.map(({ key, label, testId }) => (
+        <div key={key} className={styles.stat} data-stat={key} data-testid={testId}>
+          <span className={styles.statVal} data-stat-val>{values[key]}</span>
+          <span className={styles.statLabel}>{label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/screens/great-hall/index.tsx
+++ b/apps/web/src/screens/great-hall/index.tsx
@@ -1,5 +1,1 @@
-// GreatHallScreen — TODO: implement
-// Reference: saga-keeper-design-notes.md, saga-keeper-platform-spec.md
-export function GreatHallScreen() {
-  return <div>GreatHall</div>
-}
+export { GreatHallScreen } from './GreatHallScreen'

--- a/apps/web/src/screens/great-hall/utils/deriveReminderText.test.ts
+++ b/apps/web/src/screens/great-hall/utils/deriveReminderText.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { deriveReminderText } from './deriveReminderText'
+import type { Campaign, CharacterState } from '@saga-keeper/domain'
+import type { IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
+
+function makeCampaign(): Campaign {
+  return {
+    id: 'c1',
+    name: 'The Ashwood Oath',
+    rulesetId: 'ironsworn-v1',
+    status: 'active',
+    mode: 'solo',
+    characterIds: ['ch1'],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function makeCharacter(dataOverrides: Partial<IronswornCharacterData> = {}): CharacterState {
+  const data: IronswornCharacterData = {
+    edge: 1, heart: 2, iron: 2, shadow: 1, wits: 1,
+    health: 5, spirit: 5, supply: 5, momentum: 2,
+    debilities: { wounded: false, shaken: false, unprepared: false, encumbered: false, maimed: false, corrupted: false, cursed: false, tormented: false, weak: false },
+    vows: [],
+    bonds: [],
+    assetIds: [],
+    experience: { earned: 0, spent: 0 },
+    tracks: { combat: 0, journey: 0, bonds: 0 },
+    ...dataOverrides,
+  }
+  return {
+    id: 'ch1',
+    campaignId: 'c1',
+    name: 'Björn',
+    rulesetId: 'ironsworn-v1',
+    data: data as unknown as Record<string, unknown>,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('deriveReminderText', () => {
+  it('returns null when there is no campaign', () => {
+    expect(deriveReminderText(null, null)).toBeNull()
+  })
+
+  it('returns null when campaign is null even with a character', () => {
+    expect(deriveReminderText(null, makeCharacter())).toBeNull()
+  })
+
+  it('returns a non-null string when campaign exists but character is null', () => {
+    const text = deriveReminderText(makeCampaign(), null)
+    expect(text).not.toBeNull()
+    expect(typeof text).toBe('string')
+  })
+
+  it('warns about dire state when health < 2', () => {
+    const text = deriveReminderText(makeCampaign(), makeCharacter({ health: 1 }))
+    expect(text).toMatch(/dire/i)
+  })
+
+  it('warns about dire state when spirit < 2', () => {
+    const text = deriveReminderText(makeCampaign(), makeCharacter({ spirit: 1 }))
+    expect(text).toMatch(/dire/i)
+  })
+
+  it('warns about dire state when health is exactly 0', () => {
+    const text = deriveReminderText(makeCampaign(), makeCharacter({ health: 0 }))
+    expect(text).toMatch(/dire/i)
+  })
+
+  it('warns about missing vow when character has no vows', () => {
+    const text = deriveReminderText(makeCampaign(), makeCharacter({ vows: [] }))
+    expect(text).toMatch(/vow/i)
+  })
+
+  it('returns saga continues when character has vows and is healthy', () => {
+    const text = deriveReminderText(
+      makeCampaign(),
+      makeCharacter({
+        vows: [{ id: 'v1', title: 'Test', rank: 'dangerous', progress: 3, fulfilled: false }],
+        health: 4,
+        spirit: 4,
+      }),
+    )
+    expect(text).toMatch(/saga continues/i)
+  })
+
+  it('health exactly 2 is not dire (boundary)', () => {
+    const text = deriveReminderText(makeCampaign(), makeCharacter({ health: 2, spirit: 5 }))
+    expect(text).not.toMatch(/dire/i)
+  })
+
+  it('spirit exactly 2 is not dire (boundary)', () => {
+    const text = deriveReminderText(makeCampaign(), makeCharacter({ spirit: 2, health: 5 }))
+    expect(text).not.toMatch(/dire/i)
+  })
+})

--- a/apps/web/src/screens/great-hall/utils/deriveReminderText.ts
+++ b/apps/web/src/screens/great-hall/utils/deriveReminderText.ts
@@ -1,0 +1,29 @@
+import type { Campaign, CharacterState } from '@saga-keeper/domain'
+import type { IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
+
+/**
+ * Derives a Skald's Reminder message from campaign and character state.
+ * Returns null when no campaign is active (empty-state handled by the card).
+ */
+export function deriveReminderText(
+  campaign: Campaign | null,
+  character: CharacterState | null,
+): string | null {
+  if (!campaign) return null
+
+  if (!character) {
+    return 'Begin a new saga to receive counsel from the Skald.'
+  }
+
+  const data = character.data as unknown as IronswornCharacterData
+
+  if (data.health < 2 || data.spirit < 2) {
+    return 'Your character is in a dire state. Tend to your wounds before pressing forward.'
+  }
+
+  if (!data.vows || data.vows.length === 0) {
+    return 'No iron vow binds your path. Consider swearing one before venturing further.'
+  }
+
+  return 'Your saga continues. The Skald awaits your next move.'
+}

--- a/apps/web/src/screens/great-hall/utils/formatRelativeDate.test.ts
+++ b/apps/web/src/screens/great-hall/utils/formatRelativeDate.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { formatRelativeDate } from './formatRelativeDate'
+
+function daysAgo(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString()
+}
+
+describe('formatRelativeDate', () => {
+  it('returns empty string for undefined', () => {
+    expect(formatRelativeDate(undefined)).toBe('')
+  })
+
+  it('returns "Today" for a timestamp from earlier today', () => {
+    expect(formatRelativeDate(new Date().toISOString())).toBe('Today')
+  })
+
+  it('returns "Yesterday" for 1 day ago', () => {
+    expect(formatRelativeDate(daysAgo(1))).toBe('Yesterday')
+  })
+
+  it('returns "2 days ago" for 2 days ago', () => {
+    expect(formatRelativeDate(daysAgo(2))).toBe('2 days ago')
+  })
+
+  it('returns "6 days ago" for 6 days ago', () => {
+    expect(formatRelativeDate(daysAgo(6))).toBe('6 days ago')
+  })
+
+  it('returns "1 week ago" for 7 days ago', () => {
+    expect(formatRelativeDate(daysAgo(7))).toBe('1 week ago')
+  })
+
+  it('returns "2 weeks ago" for 14 days ago', () => {
+    expect(formatRelativeDate(daysAgo(14))).toBe('2 weeks ago')
+  })
+
+  it('returns weeks for larger values', () => {
+    expect(formatRelativeDate(daysAgo(30))).toBe('4 weeks ago')
+  })
+})

--- a/apps/web/src/screens/great-hall/utils/formatRelativeDate.ts
+++ b/apps/web/src/screens/great-hall/utils/formatRelativeDate.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns a human-readable relative date string for an ISO timestamp.
+ * "Today" | "Yesterday" | "N days ago" | "N weeks ago"
+ */
+export function formatRelativeDate(iso: string | undefined): string {
+  if (!iso) return ''
+  const now = new Date()
+  const then = new Date(iso)
+  const diffMs = now.getTime() - then.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7) return `${diffDays} days ago`
+  const weeks = Math.floor(diffDays / 7)
+  return `${weeks} week${weeks === 1 ? '' : 's'} ago`
+}

--- a/apps/web/src/screens/great-hall/utils/sessionEventsToActivityItems.test.ts
+++ b/apps/web/src/screens/great-hall/utils/sessionEventsToActivityItems.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { sessionEventsToActivityItems } from './sessionEventsToActivityItems'
+import type { SessionEvent } from '@saga-keeper/domain'
+
+function makeEvent(overrides: Partial<SessionEvent> = {}): SessionEvent {
+  return {
+    id: Math.random().toString(36).slice(2),
+    campaignId: 'c1',
+    turnId: 't1',
+    type: 'move.resolved',
+    playerId: 'p1',
+    payload: {},
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('sessionEventsToActivityItems', () => {
+  it('returns an empty array for empty input', () => {
+    expect(sessionEventsToActivityItems([], 'My Campaign')).toEqual([])
+  })
+
+  it('maps oracle.consulted to gold dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'oracle.consulted' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('gold')
+  })
+
+  it('maps vow.updated to gold dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'vow.updated' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('gold')
+  })
+
+  it('maps entity.extracted to blue dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'entity.extracted' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('blue')
+  })
+
+  it('maps character.mutated to red dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'character.mutated' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('red')
+  })
+
+  it('maps move.resolved to dim dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'move.resolved' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('dim')
+  })
+
+  it('maps skald.narrated to dim dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'skald.narrated' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('dim')
+  })
+
+  it('maps player.input to dim dot', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'player.input' })], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('dim')
+  })
+
+  it('uses the event type as part of the title', () => {
+    const items = sessionEventsToActivityItems([makeEvent({ type: 'oracle.consulted' })], 'My Campaign')
+    expect(items[0]?.title).toBeTruthy()
+    expect(typeof items[0]?.title).toBe('string')
+  })
+
+  it('includes campaign name in meta', () => {
+    const items = sessionEventsToActivityItems([makeEvent()], 'My Campaign')
+    expect(items[0]?.meta).toContain('My Campaign')
+  })
+
+  it('includes a relative date in meta', () => {
+    const items = sessionEventsToActivityItems([makeEvent()], 'My Campaign')
+    expect(items[0]?.meta).toMatch(/today|ago|yesterday/i)
+  })
+
+  it('sorts events newest first', () => {
+    const older = makeEvent({ timestamp: '2026-01-01T00:00:00Z', type: 'move.resolved' })
+    const newer = makeEvent({ timestamp: '2026-06-01T00:00:00Z', type: 'oracle.consulted' })
+    const items = sessionEventsToActivityItems([older, newer], 'My Campaign')
+    expect(items[0]?.dotColor).toBe('gold') // newer (oracle) is first
+    expect(items[1]?.dotColor).toBe('dim')  // older (move) is second
+  })
+
+  it('limits output to 6 items', () => {
+    const events = Array.from({ length: 10 }, (_, i) =>
+      makeEvent({ id: `e${i}`, timestamp: new Date(Date.now() - i * 1000).toISOString() }),
+    )
+    expect(sessionEventsToActivityItems(events, 'My Campaign').length).toBe(6)
+  })
+
+  it('returns items with id, title, meta, dotColor fields', () => {
+    const items = sessionEventsToActivityItems([makeEvent()], 'My Campaign')
+    const item = items[0]!
+    expect(typeof item.id).toBe('string')
+    expect(typeof item.title).toBe('string')
+    expect(typeof item.meta).toBe('string')
+    expect(typeof item.dotColor).toBe('string')
+  })
+})

--- a/apps/web/src/screens/great-hall/utils/sessionEventsToActivityItems.ts
+++ b/apps/web/src/screens/great-hall/utils/sessionEventsToActivityItems.ts
@@ -1,0 +1,52 @@
+import type { SessionEvent, SessionEventType } from '@saga-keeper/domain'
+import { formatRelativeDate } from './formatRelativeDate'
+
+export type ActivityDotColor = 'gold' | 'blue' | 'red' | 'dim'
+
+export interface ActivityItem {
+  id: string
+  title: string
+  meta: string
+  dotColor: ActivityDotColor
+}
+
+const EVENT_COLOR: Record<SessionEventType, ActivityDotColor> = {
+  'oracle.consulted': 'gold',
+  'vow.updated': 'gold',
+  'entity.extracted': 'blue',
+  'character.mutated': 'red',
+  'move.resolved': 'dim',
+  'skald.narrated': 'dim',
+  'player.input': 'dim',
+  'dice.rolled': 'dim',
+  'session.started': 'dim',
+  'session.ended': 'dim',
+}
+
+const EVENT_TITLE: Record<SessionEventType, string> = {
+  'oracle.consulted': 'Oracle consulted',
+  'vow.updated': 'Vow progress updated',
+  'entity.extracted': 'New entity discovered',
+  'character.mutated': 'Character state changed',
+  'move.resolved': 'Move resolved',
+  'skald.narrated': 'Skald narrated',
+  'player.input': 'Player action',
+  'dice.rolled': 'Dice rolled',
+  'session.started': 'Session started',
+  'session.ended': 'Session ended',
+}
+
+export function sessionEventsToActivityItems(
+  events: SessionEvent[],
+  campaignName: string,
+): ActivityItem[] {
+  return [...events]
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+    .slice(0, 6)
+    .map((event) => ({
+      id: event.id,
+      title: EVENT_TITLE[event.type] ?? event.type,
+      meta: `${campaignName} · ${formatRelativeDate(event.timestamp) || 'Just now'}`,
+      dotColor: EVENT_COLOR[event.type] ?? 'dim',
+    }))
+}

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.module.css
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.module.css
@@ -19,10 +19,14 @@
   backdrop-filter: blur(8px);
 }
 
-.headerLogo {
+.logoBtn {
   display: flex;
   align-items: center;
   gap: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
 }
 
 .logoTitle {

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.test.tsx
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.test.tsx
@@ -159,6 +159,12 @@ describe('IronSheetScreen — store mutations', () => {
 })
 
 describe('IronSheetScreen — accessibility', () => {
+  it('clicking the logo navigates to /great-hall', () => {
+    render(<IronSheetScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /go to great hall/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
+  })
+
   it('has a <main> landmark', () => {
     render(<IronSheetScreen />)
     expect(screen.getByRole('main')).toBeTruthy()

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.test.tsx
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.test.tsx
@@ -187,4 +187,12 @@ describe('IronSheetScreen — accessibility', () => {
     fireEvent.click(screen.getByRole('button', { name: /oracle/i }))
     expect(mockNavigate).toHaveBeenCalledWith('/oracle')
   })
+
+  it('Skald nav button is enabled and navigates to /skald', () => {
+    render(<IronSheetScreen />)
+    const skaldBtn = screen.getByRole('button', { name: /skald/i })
+    expect((skaldBtn as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(skaldBtn)
+    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+  })
 })

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.tsx
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.tsx
@@ -15,7 +15,7 @@ import styles from './IronSheetScreen.module.css'
 const NAV_ITEMS = [
   { label: 'Iron Sheet', path: '/iron-sheet' },
   { label: 'Oracle', path: '/oracle' },
-  { label: 'Skald', path: null },
+  { label: 'Skald', path: '/skald' },
   { label: 'World Forge', path: null },
 ]
 

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.tsx
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.tsx
@@ -110,9 +110,14 @@ export function IronSheetScreen() {
 function renderHeader(navigate: ReturnType<typeof useNavigate>, currentPath: string) {
   return (
     <header className={styles.header}>
-      <div className={styles.headerLogo}>
+      <button
+        type="button"
+        className={styles.logoBtn}
+        aria-label="Go to Great Hall"
+        onClick={() => navigate('/great-hall')}
+      >
         <span className={styles.logoTitle}>Saga Keeper</span>
-      </div>
+      </button>
       <nav className={styles.headerNav} aria-label="Application">
         {NAV_ITEMS.map(({ label, path }) => (
           <button

--- a/apps/web/src/screens/oracle/OracleScreen.module.css
+++ b/apps/web/src/screens/oracle/OracleScreen.module.css
@@ -19,10 +19,14 @@
   backdrop-filter: blur(8px);
 }
 
-.headerLogo {
+.logoBtn {
   display: flex;
   align-items: center;
   gap: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
 }
 
 .logoTitle {

--- a/apps/web/src/screens/oracle/OracleScreen.test.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.test.tsx
@@ -74,4 +74,12 @@ describe('OracleScreen — accessibility', () => {
     render(<OracleScreen />)
     expect(screen.getByText(/saga keeper/i)).toBeTruthy()
   })
+
+  it('Skald nav button is enabled and navigates to /skald', () => {
+    render(<OracleScreen />)
+    const skaldBtn = screen.getByRole('button', { name: /skald/i })
+    expect((skaldBtn as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(skaldBtn)
+    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+  })
 })

--- a/apps/web/src/screens/oracle/OracleScreen.test.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.test.tsx
@@ -75,6 +75,12 @@ describe('OracleScreen — accessibility', () => {
     expect(screen.getByText(/saga keeper/i)).toBeTruthy()
   })
 
+  it('clicking the logo navigates to /great-hall', () => {
+    render(<OracleScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /go to great hall/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
+  })
+
   it('Skald nav button is enabled and navigates to /skald', () => {
     render(<OracleScreen />)
     const skaldBtn = screen.getByRole('button', { name: /skald/i })

--- a/apps/web/src/screens/oracle/OracleScreen.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.tsx
@@ -45,9 +45,14 @@ export function OracleScreen() {
   return (
     <div className={styles.screen}>
       <header className={styles.header} role="banner">
-        <div className={styles.headerLogo}>
+        <button
+          type="button"
+          className={styles.logoBtn}
+          aria-label="Go to Great Hall"
+          onClick={() => navigate('/great-hall')}
+        >
           <span className={styles.logoTitle}>Saga Keeper</span>
-        </div>
+        </button>
         <nav className={styles.headerNav} aria-label="Application">
           {NAV_ITEMS.map(({ label, path }) => (
             <button

--- a/apps/web/src/screens/oracle/OracleScreen.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.tsx
@@ -10,7 +10,7 @@ import styles from './OracleScreen.module.css'
 const NAV_ITEMS = [
   { label: 'Iron Sheet', path: '/iron-sheet' },
   { label: 'Oracle', path: '/oracle' },
-  { label: 'Skald', path: null },
+  { label: 'Skald', path: '/skald' },
   { label: 'World Forge', path: null },
 ]
 

--- a/apps/web/src/screens/skald/SkaldScreen.module.css
+++ b/apps/web/src/screens/skald/SkaldScreen.module.css
@@ -1,7 +1,7 @@
 .screen {
   display: grid;
   grid-template-rows: 47px 1fr;
-  min-height: 100vh;
+  height: 100vh;
   background: var(--color-void, #0d0b08);
   color: var(--color-parchment, #c4a96e);
   font-family: 'Cinzel', Georgia, serif;
@@ -89,7 +89,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: visible;
+  overflow: hidden;
   outline: none;
 }
 

--- a/apps/web/src/screens/skald/SkaldScreen.module.css
+++ b/apps/web/src/screens/skald/SkaldScreen.module.css
@@ -1,0 +1,128 @@
+.screen {
+  display: grid;
+  grid-template-rows: 47px 1fr;
+  min-height: 100vh;
+  background: var(--color-void, #0d0b08);
+  color: var(--color-parchment, #c4a96e);
+  font-family: 'Cinzel', Georgia, serif;
+}
+
+/* ── HEADER ── */
+.header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 32px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.2);
+  background: rgba(30, 23, 16, 0.95);
+  backdrop-filter: blur(8px);
+}
+
+.headerLogo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.logoTitle {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 14px;
+  font-weight: 900;
+  color: var(--color-gold-bright, #f0b429);
+  letter-spacing: 3px;
+  text-transform: uppercase;
+}
+
+.headerNav {
+  display: flex;
+  gap: 2px;
+}
+
+.navBtn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-bone, #7a6a52);
+  padding: 6px 14px;
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s;
+  border-radius: 2px;
+  height: 47px;
+}
+
+.navBtn:hover,
+.navBtn[aria-current='page'] {
+  border-color: rgba(212, 148, 26, 0.4);
+  color: var(--color-gold, #d4941a);
+  background: rgba(212, 148, 26, 0.08);
+}
+
+.navBtn:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+/* ── BODY ── */
+.body {
+  display: grid;
+  grid-template-columns: 200px 1fr 260px;
+  overflow: hidden;
+  height: 100%;
+}
+
+/* ── LEFT SIDEBAR ── */
+.leftSidebar {
+  border-right: 1px solid rgba(212, 148, 26, 0.12);
+  background: rgba(15, 13, 10, 0.85);
+  padding: 16px 10px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── MAIN (CHAT COLUMN) ── */
+.main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  outline: none;
+  position: relative;
+}
+
+.pageTitle {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 11px;
+  letter-spacing: 6px;
+  color: var(--color-bone, #7a6a52);
+  text-transform: uppercase;
+  margin: 0;
+  padding: 14px 20px 10px;
+  border-bottom: 1px solid rgba(30, 23, 16, 1);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.pageTitle::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(212, 148, 26, 0.2), transparent);
+}
+
+/* ── RIGHT PANEL ── */
+.rightPanel {
+  border-left: 1px solid rgba(212, 148, 26, 0.12);
+  background: rgba(10, 8, 6, 0.9);
+  padding: 14px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}

--- a/apps/web/src/screens/skald/SkaldScreen.module.css
+++ b/apps/web/src/screens/skald/SkaldScreen.module.css
@@ -19,10 +19,14 @@
   backdrop-filter: blur(8px);
 }
 
-.headerLogo {
+.logoBtn {
   display: flex;
   align-items: center;
   gap: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
 }
 
 .logoTitle {

--- a/apps/web/src/screens/skald/SkaldScreen.module.css
+++ b/apps/web/src/screens/skald/SkaldScreen.module.css
@@ -89,9 +89,13 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow: visible;
   outline: none;
+}
+
+.inputArea {
   position: relative;
+  flex-shrink: 0;
 }
 
 .pageTitle {

--- a/apps/web/src/screens/skald/SkaldScreen.test.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.test.tsx
@@ -78,9 +78,14 @@ describe('SkaldScreen — layout landmarks', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')
   })
 
-  it('clicking Oracle calls navigate("/oracle")', () => {
+  it('clicking Oracle nav button calls navigate("/oracle")', () => {
     render(<SkaldScreen />)
-    fireEvent.click(screen.getByRole('button', { name: /oracle/i }))
+    const nav = screen.getByRole('navigation', { name: /application/i })
+    const oracleNavBtn = nav.querySelector('button[aria-current], button') as HTMLButtonElement
+    // Find the Oracle button specifically within nav (accessible name is exactly "Oracle")
+    const buttons = Array.from(nav.querySelectorAll('button'))
+    const oracleBtn = buttons.find((b) => b.textContent?.trim() === 'Oracle')!
+    fireEvent.click(oracleBtn)
     expect(mockNavigate).toHaveBeenCalledWith('/oracle')
   })
 

--- a/apps/web/src/screens/skald/SkaldScreen.test.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.test.tsx
@@ -14,6 +14,10 @@ vi.mock('@/store', () => ({
   useGameStore: vi.fn(),
 }))
 
+vi.mock('@/providers/NarrativeDomainProvider', () => ({
+  useNarrativeDomain: vi.fn(() => ({ processTurn: vi.fn() })),
+}))
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setupStore(overrides: Record<string, unknown> = {}) {
   vi.mocked(useGameStore).mockImplementation((selector: (s: any) => unknown) => {
@@ -35,6 +39,8 @@ function setupStore(overrides: Record<string, unknown> = {}) {
       recordOracleRoll: vi.fn(),
       appendMessage: vi.fn(),
       setPhase: vi.fn(),
+      setPendingAction: vi.fn(),
+      applyTurnResult: vi.fn(),
       ...overrides,
     }
     return selector(state)

--- a/apps/web/src/screens/skald/SkaldScreen.test.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { SkaldScreen } from './SkaldScreen'
 import { useGameStore } from '@/store'
 
@@ -81,11 +81,7 @@ describe('SkaldScreen — layout landmarks', () => {
   it('clicking Oracle nav button calls navigate("/oracle")', () => {
     render(<SkaldScreen />)
     const nav = screen.getByRole('navigation', { name: /application/i })
-    const oracleNavBtn = nav.querySelector('button[aria-current], button') as HTMLButtonElement
-    // Find the Oracle button specifically within nav (accessible name is exactly "Oracle")
-    const buttons = Array.from(nav.querySelectorAll('button'))
-    const oracleBtn = buttons.find((b) => b.textContent?.trim() === 'Oracle')!
-    fireEvent.click(oracleBtn)
+    fireEvent.click(within(nav).getByRole('button', { name: /^oracle$/i }))
     expect(mockNavigate).toHaveBeenCalledWith('/oracle')
   })
 

--- a/apps/web/src/screens/skald/SkaldScreen.test.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.test.tsx
@@ -122,6 +122,12 @@ describe('SkaldScreen — layout landmarks', () => {
 })
 
 describe('SkaldScreen — accessibility', () => {
+  it('clicking the logo navigates to /great-hall', () => {
+    render(<SkaldScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /go to great hall/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
+  })
+
   it('World Forge nav button is disabled', () => {
     render(<SkaldScreen />)
     const worldForgeBtn = screen.getByRole('button', { name: /world forge/i })

--- a/apps/web/src/screens/skald/SkaldScreen.test.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SkaldScreen } from './SkaldScreen'
+import { useGameStore } from '@/store'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/skald' }),
+}))
+
+vi.mock('@/store', () => ({
+  useGameStore: vi.fn(),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setupStore(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useGameStore).mockImplementation((selector: (s: any) => unknown) => {
+    const state = {
+      messages: [],
+      phase: 'idle',
+      streamBuffer: '',
+      character: null,
+      campaign: null,
+      turns: [],
+      pendingAction: null,
+      draft: { tableId: null, odds: null },
+      lastFates: null,
+      lastResult: null,
+      history: [],
+      fatesHistory: [],
+      setDraft: vi.fn(),
+      recordFates: vi.fn(),
+      recordOracleRoll: vi.fn(),
+      appendMessage: vi.fn(),
+      setPhase: vi.fn(),
+      ...overrides,
+    }
+    return selector(state)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockNavigate.mockClear()
+  setupStore()
+})
+
+describe('SkaldScreen — layout landmarks', () => {
+  it('renders a banner landmark', () => {
+    render(<SkaldScreen />)
+    expect(screen.getByRole('banner')).toBeTruthy()
+  })
+
+  it('renders navigation with aria-label "Application"', () => {
+    render(<SkaldScreen />)
+    expect(screen.getByRole('navigation', { name: /application/i })).toBeTruthy()
+  })
+
+  it('Skald nav button has aria-current="page"', () => {
+    render(<SkaldScreen />)
+    const nav = screen.getByRole('navigation', { name: /application/i })
+    const activeBtn = nav.querySelector('[aria-current="page"]')
+    expect(activeBtn).toBeTruthy()
+    expect(activeBtn!.textContent).toMatch(/skald/i)
+  })
+
+  it('Iron Sheet nav button does not have aria-current', () => {
+    render(<SkaldScreen />)
+    const ironSheetBtn = screen.getByRole('button', { name: /iron sheet/i })
+    expect(ironSheetBtn.getAttribute('aria-current')).toBeNull()
+  })
+
+  it('clicking Iron Sheet calls navigate("/iron-sheet")', () => {
+    render(<SkaldScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /iron sheet/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')
+  })
+
+  it('clicking Oracle calls navigate("/oracle")', () => {
+    render(<SkaldScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /oracle/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/oracle')
+  })
+
+  it('renders main landmark with tabIndex -1', () => {
+    render(<SkaldScreen />)
+    const main = screen.getByRole('main')
+    expect(main).toBeTruthy()
+    expect(main.tabIndex).toBe(-1)
+  })
+
+  it('renders left aside with aria-label "Character & Sessions"', () => {
+    render(<SkaldScreen />)
+    expect(
+      screen.getByRole('complementary', { name: /character & sessions/i }),
+    ).toBeTruthy()
+  })
+
+  it('renders right aside with aria-label "Scene & Moves"', () => {
+    render(<SkaldScreen />)
+    expect(screen.getByRole('complementary', { name: /scene & moves/i })).toBeTruthy()
+  })
+
+  it('renders logo text "Saga Keeper"', () => {
+    render(<SkaldScreen />)
+    expect(screen.getByText(/saga keeper/i)).toBeTruthy()
+  })
+
+  it('renders h1 heading "The Skald"', () => {
+    render(<SkaldScreen />)
+    expect(screen.getByRole('heading', { level: 1, name: /the skald/i })).toBeTruthy()
+  })
+})
+
+describe('SkaldScreen — accessibility', () => {
+  it('World Forge nav button is disabled', () => {
+    render(<SkaldScreen />)
+    const worldForgeBtn = screen.getByRole('button', { name: /world forge/i })
+    expect((worldForgeBtn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('Skald nav button is not disabled', () => {
+    render(<SkaldScreen />)
+    const nav = screen.getByRole('navigation', { name: /application/i })
+    const activeBtn = nav.querySelector('[aria-current="page"]') as HTMLButtonElement
+    expect(activeBtn.disabled).toBe(false)
+  })
+})

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -65,7 +65,7 @@ export function SkaldScreen() {
 
   return (
     <div className={styles.screen}>
-      <header className={styles.header} role="banner">
+      <header className={styles.header}>
         <div className={styles.headerLogo}>
           <span className={styles.logoTitle}>Saga Keeper</span>
         </div>

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -8,6 +8,7 @@ import { SkaldInputBar } from './components/SkaldInputBar/SkaldInputBar'
 import { SkaldLeftSidebar } from './components/SkaldLeftSidebar/SkaldLeftSidebar'
 import { SkaldRightPanel } from './components/SkaldRightPanel/SkaldRightPanel'
 import { SkaldOraclePopover } from './components/SkaldOraclePopover/SkaldOraclePopover'
+import { SkaldMovesPopover } from './components/SkaldMovesPopover/SkaldMovesPopover'
 import styles from './SkaldScreen.module.css'
 
 const NAV_ITEMS = [
@@ -21,6 +22,7 @@ export function SkaldScreen() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const [isOracleOpen, setIsOracleOpen] = useState(false)
+  const [isMovesOpen, setIsMovesOpen] = useState(false)
 
   // skaldFeedSlice
   const messages = useGameStore((s) => s.messages)
@@ -103,6 +105,14 @@ export function SkaldScreen() {
               onMoveSelect={handleMoveSelect}
               onOracleOpen={() => setIsOracleOpen((prev) => !prev)}
               isOracleOpen={isOracleOpen}
+              onMovesOpen={() => setIsMovesOpen((prev) => !prev)}
+              isMovesOpen={isMovesOpen}
+            />
+            <SkaldMovesPopover
+              isOpen={isMovesOpen}
+              isBusy={phase === 'resolving' || phase === 'waiting-for-ai' || phase === 'streaming'}
+              onClose={() => setIsMovesOpen(false)}
+              onMoveSelect={handleMoveSelect}
             />
             <SkaldOraclePopover isOpen={isOracleOpen} onClose={() => setIsOracleOpen(false)} />
           </div>

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -6,6 +6,7 @@ import { SkaldFeed } from './components/SkaldFeed/SkaldFeed'
 import { SkaldInputBar } from './components/SkaldInputBar/SkaldInputBar'
 import { SkaldLeftSidebar } from './components/SkaldLeftSidebar/SkaldLeftSidebar'
 import { SkaldRightPanel } from './components/SkaldRightPanel/SkaldRightPanel'
+import { SkaldOraclePopover } from './components/SkaldOraclePopover/SkaldOraclePopover'
 import styles from './SkaldScreen.module.css'
 
 const NAV_ITEMS = [
@@ -100,7 +101,7 @@ export function SkaldScreen() {
             onOracleOpen={() => setIsOracleOpen((prev) => !prev)}
             isOracleOpen={isOracleOpen}
           />
-          {/* SkaldOraclePopover — chunk 6 */}
+          <SkaldOraclePopover isOpen={isOracleOpen} onClose={() => setIsOracleOpen(false)} />
         </main>
 
         <aside className={styles.rightPanel} aria-label="Scene & Moves">

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -1,4 +1,6 @@
 import { useNavigate, useLocation } from 'react-router-dom'
+import { useGameStore } from '@/store'
+import { SkaldFeed } from './components/SkaldFeed/SkaldFeed'
 import styles from './SkaldScreen.module.css'
 
 const NAV_ITEMS = [
@@ -11,6 +13,9 @@ const NAV_ITEMS = [
 export function SkaldScreen() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
+  const messages = useGameStore((s) => s.messages)
+  const phase = useGameStore((s) => s.phase)
+  const streamBuffer = useGameStore((s) => s.streamBuffer)
 
   return (
     <div className={styles.screen}>
@@ -41,7 +46,7 @@ export function SkaldScreen() {
 
         <main className={styles.main} role="main" tabIndex={-1}>
           <h1 className={styles.pageTitle}>The Skald</h1>
-          {/* SkaldFeed — chunk 2 */}
+          <SkaldFeed messages={messages} phase={phase} streamBuffer={streamBuffer} />
           {/* SkaldInputBar — chunk 3 */}
         </main>
 

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -5,6 +5,7 @@ import { useGameStore } from '@/store'
 import { SkaldFeed } from './components/SkaldFeed/SkaldFeed'
 import { SkaldInputBar } from './components/SkaldInputBar/SkaldInputBar'
 import { SkaldLeftSidebar } from './components/SkaldLeftSidebar/SkaldLeftSidebar'
+import { SkaldRightPanel } from './components/SkaldRightPanel/SkaldRightPanel'
 import styles from './SkaldScreen.module.css'
 
 const NAV_ITEMS = [
@@ -27,6 +28,9 @@ export function SkaldScreen() {
 
   // characterSlice
   const character = useGameStore((s) => s.character)
+
+  // sessionSlice
+  const pendingAction = useGameStore((s) => s.pendingAction)
 
   const suggestedMoves = character
     ? ironswornPlugin.moves.suggest({
@@ -100,7 +104,11 @@ export function SkaldScreen() {
         </main>
 
         <aside className={styles.rightPanel} aria-label="Scene & Moves">
-          {/* SkaldRightPanel — chunk 5 */}
+          <SkaldRightPanel
+            character={character}
+            pendingAction={pendingAction}
+            phase={phase}
+          />
         </aside>
       </div>
     </div>

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -1,0 +1,54 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+import styles from './SkaldScreen.module.css'
+
+const NAV_ITEMS = [
+  { label: 'Iron Sheet', path: '/iron-sheet' },
+  { label: 'Oracle', path: '/oracle' },
+  { label: 'Skald', path: '/skald' },
+  { label: 'World Forge', path: null },
+]
+
+export function SkaldScreen() {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  return (
+    <div className={styles.screen}>
+      <header className={styles.header} role="banner">
+        <div className={styles.headerLogo}>
+          <span className={styles.logoTitle}>Saga Keeper</span>
+        </div>
+        <nav className={styles.headerNav} aria-label="Application">
+          {NAV_ITEMS.map(({ label, path }) => (
+            <button
+              key={label}
+              type="button"
+              className={styles.navBtn}
+              aria-current={path === pathname ? 'page' : undefined}
+              disabled={path === null}
+              onClick={path ? () => navigate(path) : undefined}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <div className={styles.body}>
+        <aside className={styles.leftSidebar} aria-label="Character & Sessions">
+          {/* SkaldLeftSidebar — chunk 4 */}
+        </aside>
+
+        <main className={styles.main} role="main" tabIndex={-1}>
+          <h1 className={styles.pageTitle}>The Skald</h1>
+          {/* SkaldFeed — chunk 2 */}
+          {/* SkaldInputBar — chunk 3 */}
+        </main>
+
+        <aside className={styles.rightPanel} aria-label="Scene & Moves">
+          {/* SkaldRightPanel — chunk 5 */}
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -93,15 +93,17 @@ export function SkaldScreen() {
         <main className={styles.main} role="main" tabIndex={-1}>
           <h1 className={styles.pageTitle}>The Skald</h1>
           <SkaldFeed messages={messages} phase={phase} streamBuffer={streamBuffer} />
-          <SkaldInputBar
-            phase={phase}
-            moves={suggestedMoves}
-            onSend={handleSend}
-            onMoveSelect={handleMoveSelect}
-            onOracleOpen={() => setIsOracleOpen((prev) => !prev)}
-            isOracleOpen={isOracleOpen}
-          />
-          <SkaldOraclePopover isOpen={isOracleOpen} onClose={() => setIsOracleOpen(false)} />
+          <div className={styles.inputArea}>
+            <SkaldInputBar
+              phase={phase}
+              moves={suggestedMoves}
+              onSend={handleSend}
+              onMoveSelect={handleMoveSelect}
+              onOracleOpen={() => setIsOracleOpen((prev) => !prev)}
+              isOracleOpen={isOracleOpen}
+            />
+            <SkaldOraclePopover isOpen={isOracleOpen} onClose={() => setIsOracleOpen(false)} />
+          </div>
         </main>
 
         <aside className={styles.rightPanel} aria-label="Scene & Moves">

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -70,9 +70,14 @@ export function SkaldScreen() {
   return (
     <div className={styles.screen}>
       <header className={styles.header}>
-        <div className={styles.headerLogo}>
+        <button
+          type="button"
+          className={styles.logoBtn}
+          aria-label="Go to Great Hall"
+          onClick={() => navigate('/great-hall')}
+        >
           <span className={styles.logoTitle}>Saga Keeper</span>
-        </div>
+        </button>
         <nav className={styles.headerNav} aria-label="Application">
           {NAV_ITEMS.map(({ label, path }) => (
             <button

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -4,6 +4,7 @@ import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
 import { SkaldFeed } from './components/SkaldFeed/SkaldFeed'
 import { SkaldInputBar } from './components/SkaldInputBar/SkaldInputBar'
+import { SkaldLeftSidebar } from './components/SkaldLeftSidebar/SkaldLeftSidebar'
 import styles from './SkaldScreen.module.css'
 
 const NAV_ITEMS = [
@@ -81,7 +82,7 @@ export function SkaldScreen() {
 
       <div className={styles.body}>
         <aside className={styles.leftSidebar} aria-label="Character & Sessions">
-          {/* SkaldLeftSidebar — chunk 4 */}
+          <SkaldLeftSidebar character={character} />
         </aside>
 
         <main className={styles.main} role="main" tabIndex={-1}>

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
 import { SkaldFeed } from './components/SkaldFeed/SkaldFeed'
+import { SkaldInputBar } from './components/SkaldInputBar/SkaldInputBar'
 import styles from './SkaldScreen.module.css'
 
 const NAV_ITEMS = [
@@ -13,9 +16,46 @@ const NAV_ITEMS = [
 export function SkaldScreen() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
+  const [isOracleOpen, setIsOracleOpen] = useState(false)
+
+  // skaldFeedSlice
   const messages = useGameStore((s) => s.messages)
   const phase = useGameStore((s) => s.phase)
   const streamBuffer = useGameStore((s) => s.streamBuffer)
+  const appendMessage = useGameStore((s) => s.appendMessage)
+
+  // characterSlice
+  const character = useGameStore((s) => s.character)
+
+  const suggestedMoves = character
+    ? ironswornPlugin.moves.suggest({
+        characterState: character,
+        inCombat: false,
+        onJourney: false,
+        recentMoves: [],
+      })
+    : ironswornPlugin.moves.getByCategory('adventure').slice(0, 5)
+
+  function handleSend(text: string) {
+    appendMessage({
+      id: globalThis.crypto.randomUUID(),
+      role: 'player',
+      content: text,
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  function handleMoveSelect(moveId: string) {
+    const move = ironswornPlugin.moves.getAll().find((m) => m.id === moveId)
+    if (move) {
+      appendMessage({
+        id: globalThis.crypto.randomUUID(),
+        role: 'player',
+        content: `[${move.name}] ${move.trigger}`,
+        timestamp: new Date().toISOString(),
+      })
+    }
+  }
 
   return (
     <div className={styles.screen}>
@@ -47,7 +87,15 @@ export function SkaldScreen() {
         <main className={styles.main} role="main" tabIndex={-1}>
           <h1 className={styles.pageTitle}>The Skald</h1>
           <SkaldFeed messages={messages} phase={phase} streamBuffer={streamBuffer} />
-          {/* SkaldInputBar — chunk 3 */}
+          <SkaldInputBar
+            phase={phase}
+            moves={suggestedMoves}
+            onSend={handleSend}
+            onMoveSelect={handleMoveSelect}
+            onOracleOpen={() => setIsOracleOpen((prev) => !prev)}
+            isOracleOpen={isOracleOpen}
+          />
+          {/* SkaldOraclePopover — chunk 6 */}
         </main>
 
         <aside className={styles.rightPanel} aria-label="Scene & Moves">

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -99,7 +99,7 @@ export function SkaldScreen() {
           <SkaldLeftSidebar character={character} />
         </aside>
 
-        <main className={styles.main} role="main" tabIndex={-1}>
+        <main className={styles.main} tabIndex={-1}>
           <h1 className={styles.pageTitle}>The Skald</h1>
           <SkaldFeed messages={messages} phase={phase} streamBuffer={streamBuffer} />
           <div className={styles.inputArea}>

--- a/apps/web/src/screens/skald/SkaldScreen.tsx
+++ b/apps/web/src/screens/skald/SkaldScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
+import { useSkaldTurn } from './hooks/useSkaldTurn'
 import { SkaldFeed } from './components/SkaldFeed/SkaldFeed'
 import { SkaldInputBar } from './components/SkaldInputBar/SkaldInputBar'
 import { SkaldLeftSidebar } from './components/SkaldLeftSidebar/SkaldLeftSidebar'
@@ -25,13 +26,18 @@ export function SkaldScreen() {
   const messages = useGameStore((s) => s.messages)
   const phase = useGameStore((s) => s.phase)
   const streamBuffer = useGameStore((s) => s.streamBuffer)
-  const appendMessage = useGameStore((s) => s.appendMessage)
 
   // characterSlice
   const character = useGameStore((s) => s.character)
 
   // sessionSlice
   const pendingAction = useGameStore((s) => s.pendingAction)
+  const campaignId = useGameStore((s) => s.campaign?.id ?? '')
+
+  const { submitAction } = useSkaldTurn({
+    campaignId,
+    ...(character?.id ? { characterId: character.id } : {}),
+  })
 
   const suggestedMoves = character
     ? ironswornPlugin.moves.suggest({
@@ -43,24 +49,20 @@ export function SkaldScreen() {
     : ironswornPlugin.moves.getByCategory('adventure').slice(0, 5)
 
   function handleSend(text: string) {
-    appendMessage({
-      id: globalThis.crypto.randomUUID(),
-      role: 'player',
-      content: text,
-      timestamp: new Date().toISOString(),
-    })
+    if (!campaignId) return
+    void submitAction({ type: 'free', ...(character?.id ? { characterId: character.id } : {}), userText: text })
   }
 
   function handleMoveSelect(moveId: string) {
+    if (!campaignId) return
     const move = ironswornPlugin.moves.getAll().find((m) => m.id === moveId)
-    if (move) {
-      appendMessage({
-        id: globalThis.crypto.randomUUID(),
-        role: 'player',
-        content: `[${move.name}] ${move.trigger}`,
-        timestamp: new Date().toISOString(),
-      })
-    }
+    if (!move) return
+    void submitAction({
+      type: 'move',
+      moveId,
+      ...(character?.id ? { characterId: character.id } : {}),
+      statKey: move.stats[0] ?? 'edge',
+    })
   }
 
   return (

--- a/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.module.css
+++ b/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.module.css
@@ -1,0 +1,139 @@
+.card {
+  border: 1px solid rgba(212, 148, 26, 0.3);
+  border-radius: 4px;
+  background: var(--color-ash, #13100d);
+  overflow: hidden;
+}
+
+/* ── Header row ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.12);
+}
+
+.moveName {
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--color-parchment, #c4a96e);
+  font-weight: 600;
+}
+
+.badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.badge {
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 2px;
+  border: 1px solid;
+}
+
+.badgeStrongHit {
+  color: #5cb85c;
+  border-color: rgba(92, 184, 92, 0.4);
+  background: rgba(92, 184, 92, 0.08);
+}
+
+.badgeWeakHit {
+  color: var(--color-gold-bright, #f0b429);
+  border-color: rgba(240, 180, 41, 0.4);
+  background: rgba(240, 180, 41, 0.08);
+}
+
+.badgeMiss {
+  color: var(--color-blood-bright, #c0392b);
+  border-color: rgba(192, 57, 43, 0.4);
+  background: rgba(192, 57, 43, 0.08);
+}
+
+.matchPill {
+  font-size: 7px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 3px 7px;
+  border-radius: 2px;
+  color: var(--color-gold-bright, #f0b429);
+  border: 1px solid rgba(240, 180, 41, 0.5);
+  background: rgba(240, 180, 41, 0.12);
+}
+
+/* ── Body ── */
+.body {
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Dice row ── */
+.diceRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  color: var(--color-bone, #7a6a52);
+  font-variant-numeric: tabular-nums;
+}
+
+.diceTotal {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-parchment, #c4a96e);
+}
+
+.diceSep {
+  color: var(--color-stone, #3d3428);
+  font-size: 10px;
+}
+
+.diceChallenge {
+  font-size: 10px;
+  color: var(--color-bone, #7a6a52);
+}
+
+/* ── Consequences ── */
+.consequences {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.delta {
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 2px;
+  font-weight: 600;
+}
+
+.deltaPositive {
+  color: #5cb85c;
+  background: rgba(92, 184, 92, 0.1);
+  border: 1px solid rgba(92, 184, 92, 0.25);
+}
+
+.deltaNegative {
+  color: var(--color-blood-bright, #c0392b);
+  background: rgba(192, 57, 43, 0.1);
+  border: 1px solid rgba(192, 57, 43, 0.25);
+}
+
+.deltaNeutral {
+  color: var(--color-bone, #7a6a52);
+  background: rgba(122, 106, 82, 0.1);
+  border: 1px solid rgba(122, 106, 82, 0.25);
+}

--- a/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.test.tsx
+++ b/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MoveOutcomeCard, type MoveOutcomeData } from './MoveOutcomeCard'
+import type { DiceRollRecord } from '@saga-keeper/domain'
+
+function makeProps(overrides: Partial<MoveOutcomeData> = {}): MoveOutcomeData {
+  return {
+    moveId: 'face-danger',
+    moveName: 'Face Danger',
+    result: 'strong-hit',
+    match: false,
+    roll: null,
+    consequences: [],
+    ...overrides,
+  }
+}
+
+const sampleRoll: DiceRollRecord = {
+  actionDie: 4,
+  challengeDice: [3, 5],
+  modifier: 2,
+  total: 6,
+  result: 'strong-hit',
+  match: false,
+}
+
+describe('MoveOutcomeCard — structure', () => {
+  it('renders move name', () => {
+    render(<MoveOutcomeCard {...makeProps()} />)
+    expect(screen.getByText('Face Danger')).toBeTruthy()
+  })
+
+  it('renders result label "Strong Hit" for strong-hit', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'strong-hit' })} />)
+    expect(screen.getByText('Strong Hit')).toBeTruthy()
+  })
+
+  it('renders result label "Weak Hit" for weak-hit', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'weak-hit' })} />)
+    expect(screen.getByText('Weak Hit')).toBeTruthy()
+  })
+
+  it('renders result label "Miss" for miss', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'miss' })} />)
+    expect(screen.getByText('Miss')).toBeTruthy()
+  })
+
+  it('aria-label includes move name and result', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'weak-hit', moveName: 'Compel' })} />)
+    const card = screen.getByTestId('move-outcome-card')
+    expect(card.getAttribute('aria-label')).toBe('Compel — Weak Hit')
+  })
+})
+
+describe('MoveOutcomeCard — badge classes', () => {
+  it('strong-hit badge has correct class', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'strong-hit' })} />)
+    // The badge text is "Strong Hit" and has badgeStrongHit class
+    expect(screen.getByText('Strong Hit').className).toContain('badgeStrongHit')
+  })
+
+  it('weak-hit badge has correct class', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'weak-hit' })} />)
+    expect(screen.getByText('Weak Hit').className).toContain('badgeWeakHit')
+  })
+
+  it('miss badge has correct class', () => {
+    render(<MoveOutcomeCard {...makeProps({ result: 'miss' })} />)
+    expect(screen.getByText('Miss').className).toContain('badgeMiss')
+  })
+})
+
+describe('MoveOutcomeCard — match pill', () => {
+  it('shows "Match" pill when match is true', () => {
+    render(<MoveOutcomeCard {...makeProps({ match: true })} />)
+    expect(screen.getByText('Match')).toBeTruthy()
+  })
+
+  it('does not show "Match" pill when match is false', () => {
+    render(<MoveOutcomeCard {...makeProps({ match: false })} />)
+    expect(screen.queryByText('Match')).toBeNull()
+  })
+})
+
+describe('MoveOutcomeCard — dice row', () => {
+  it('renders dice breakdown when roll is provided', () => {
+    render(<MoveOutcomeCard {...makeProps({ roll: sampleRoll })} />)
+    const diceRow = screen.getByLabelText('Dice roll')
+    expect(diceRow).toBeTruthy()
+    // action die value
+    expect(diceRow.textContent).toContain('4')
+    // challenge dice
+    expect(diceRow.textContent).toContain('3')
+    expect(diceRow.textContent).toContain('5')
+  })
+
+  it('does not render dice row when roll is null', () => {
+    render(<MoveOutcomeCard {...makeProps({ roll: null })} />)
+    expect(screen.queryByLabelText('Dice roll')).toBeNull()
+  })
+})
+
+describe('MoveOutcomeCard — consequences', () => {
+  it('renders each consequence delta', () => {
+    render(
+      <MoveOutcomeCard
+        {...makeProps({
+          consequences: [
+            { stat: 'health', before: 5, after: 4 },
+            { stat: 'spirit', before: 3, after: 4 },
+          ],
+        })}
+      />,
+    )
+    const area = screen.getByLabelText('Consequences')
+    expect(area.textContent).toContain('Health')
+    expect(area.textContent).toContain('Spirit')
+  })
+
+  it('does not render consequences section when list is empty', () => {
+    render(<MoveOutcomeCard {...makeProps({ consequences: [] })} />)
+    expect(screen.queryByLabelText('Consequences')).toBeNull()
+  })
+
+  it('negative delta has deltaNegative class', () => {
+    render(
+      <MoveOutcomeCard
+        {...makeProps({
+          consequences: [{ stat: 'health', before: 5, after: 4 }],
+        })}
+      />,
+    )
+    const area = screen.getByLabelText('Consequences')
+    const chip = area.firstElementChild as HTMLElement
+    expect(chip.className).toContain('deltaNegative')
+  })
+
+  it('positive delta has deltaPositive class', () => {
+    render(
+      <MoveOutcomeCard
+        {...makeProps({
+          consequences: [{ stat: 'momentum', before: 2, after: 4 }],
+        })}
+      />,
+    )
+    const area = screen.getByLabelText('Consequences')
+    const chip = area.firstElementChild as HTMLElement
+    expect(chip.className).toContain('deltaPositive')
+  })
+})

--- a/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.tsx
+++ b/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.tsx
@@ -1,0 +1,105 @@
+import type { StatDelta, DiceRollRecord } from '@saga-keeper/domain'
+import styles from './MoveOutcomeCard.module.css'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface MoveOutcomeData {
+  moveId: string
+  moveName: string
+  result: 'strong-hit' | 'weak-hit' | 'miss' | null
+  match: boolean
+  roll: DiceRollRecord | null
+  consequences: StatDelta[]
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function resultLabel(result: MoveOutcomeData['result']): string {
+  if (result === 'strong-hit') return 'Strong Hit'
+  if (result === 'weak-hit') return 'Weak Hit'
+  if (result === 'miss') return 'Miss'
+  return 'Resolved'
+}
+
+function badgeClass(result: MoveOutcomeData['result']): string {
+  if (result === 'strong-hit') return `${styles.badge} ${styles.badgeStrongHit}`
+  if (result === 'weak-hit') return `${styles.badge} ${styles.badgeWeakHit}`
+  if (result === 'miss') return `${styles.badge} ${styles.badgeMiss}`
+  return styles.badge
+}
+
+function deltaSign(d: StatDelta): number {
+  return d.after - d.before
+}
+
+function deltaClass(sign: number): string {
+  if (sign > 0) return `${styles.delta} ${styles.deltaPositive}`
+  if (sign < 0) return `${styles.delta} ${styles.deltaNegative}`
+  return `${styles.delta} ${styles.deltaNeutral}`
+}
+
+function formatStat(stat: string): string {
+  return stat.charAt(0).toUpperCase() + stat.slice(1)
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function MoveOutcomeCard({
+  moveName,
+  result,
+  match,
+  roll,
+  consequences,
+}: MoveOutcomeData) {
+  const label = resultLabel(result)
+
+  return (
+    <div
+      className={styles.card}
+      aria-label={`${moveName} — ${label}`}
+      data-testid="move-outcome-card"
+    >
+      <div className={styles.header}>
+        <span className={styles.moveName}>{moveName}</span>
+        <div className={styles.badges}>
+          {match && <span className={styles.matchPill}>Match</span>}
+          <span className={badgeClass(result)}>{label}</span>
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        {roll && (
+          <div className={styles.diceRow} aria-label="Dice roll">
+            <span className={styles.diceTotal}>{roll.actionDie}</span>
+            {roll.modifier !== 0 && (
+              <>
+                <span className={styles.diceSep}>{roll.modifier > 0 ? '+' : '−'}</span>
+                <span>{Math.abs(roll.modifier)}</span>
+                <span className={styles.diceSep}>=</span>
+                <span className={styles.diceTotal}>{roll.total}</span>
+              </>
+            )}
+            <span className={styles.diceSep}>vs</span>
+            <span className={styles.diceChallenge}>
+              {roll.challengeDice[0]}, {roll.challengeDice[1]}
+            </span>
+          </div>
+        )}
+
+        {consequences.length > 0 && (
+          <div className={styles.consequences} aria-label="Consequences">
+            {consequences.map((d) => {
+              const sign = deltaSign(d)
+              return (
+                <span key={d.stat} className={deltaClass(sign)}>
+                  {formatStat(d.stat)} {sign >= 0 ? '+' : ''}
+                  {sign}
+                </span>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.tsx
+++ b/apps/web/src/screens/skald/components/MoveOutcomeCard/MoveOutcomeCard.tsx
@@ -25,7 +25,7 @@ function badgeClass(result: MoveOutcomeData['result']): string {
   if (result === 'strong-hit') return `${styles.badge} ${styles.badgeStrongHit}`
   if (result === 'weak-hit') return `${styles.badge} ${styles.badgeWeakHit}`
   if (result === 'miss') return `${styles.badge} ${styles.badgeMiss}`
-  return styles.badge
+  return styles.badge ?? ''
 }
 
 function deltaSign(d: StatDelta): number {

--- a/apps/web/src/screens/skald/components/OracleStrip/OracleStrip.module.css
+++ b/apps/web/src/screens/skald/components/OracleStrip/OracleStrip.module.css
@@ -1,0 +1,49 @@
+.strip {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 12px;
+  background: rgba(30, 23, 16, 0.6);
+  border: 1px solid rgba(212, 148, 26, 0.18);
+  border-left: 3px solid rgba(212, 148, 26, 0.45);
+  border-radius: 0 3px 3px 0;
+  align-self: flex-start;
+  max-width: 80%;
+}
+
+.icon {
+  font-size: 12px;
+  line-height: 1;
+  margin-top: 2px;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tableName {
+  font-family: 'Cinzel', serif;
+  font-size: 7px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--color-bone, #7a6a52);
+}
+
+.raw {
+  font-size: 11px;
+  color: var(--color-parchment, #c4a96e);
+  font-style: italic;
+  line-height: 1.5;
+}
+
+.roll {
+  font-size: 8px;
+  color: var(--color-stone, #3d3428);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 1px;
+}

--- a/apps/web/src/screens/skald/components/OracleStrip/OracleStrip.test.tsx
+++ b/apps/web/src/screens/skald/components/OracleStrip/OracleStrip.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OracleStrip, formatTableName } from './OracleStrip'
+
+describe('formatTableName', () => {
+  it('capitalises a single-word table', () => {
+    expect(formatTableName('theme')).toBe('Theme')
+  })
+
+  it('capitalises each word in a kebab-case table', () => {
+    expect(formatTableName('settlement-name')).toBe('Settlement Name')
+  })
+
+  it('joins compound tables with " + "', () => {
+    expect(formatTableName('action+theme')).toBe('Action + Theme')
+  })
+
+  it('handles compound tables with multi-word parts', () => {
+    expect(formatTableName('pay-the-price+iron-vow')).toBe('Pay The Price + Iron Vow')
+  })
+})
+
+describe('OracleStrip — structure', () => {
+  it('renders the raw oracle result', () => {
+    render(<OracleStrip tableId="theme" roll={42} raw="Darkness" />)
+    expect(screen.getByText('Darkness')).toBeTruthy()
+  })
+
+  it('renders the roll number', () => {
+    render(<OracleStrip tableId="theme" roll={42} raw="Darkness" />)
+    expect(screen.getByText('42')).toBeTruthy()
+  })
+
+  it('renders the formatted table name', () => {
+    render(<OracleStrip tableId="settlement-name" roll={7} raw="Ironhaven" />)
+    expect(screen.getByText('Settlement Name')).toBeTruthy()
+  })
+
+  it('aria-label includes formatted name and raw result', () => {
+    render(<OracleStrip tableId="action+theme" roll={55} raw="Seek Danger" />)
+    const strip = screen.getByTestId('oracle-strip')
+    expect(strip.getAttribute('aria-label')).toBe('Oracle: Action + Theme — Seek Danger')
+  })
+})

--- a/apps/web/src/screens/skald/components/OracleStrip/OracleStrip.tsx
+++ b/apps/web/src/screens/skald/components/OracleStrip/OracleStrip.tsx
@@ -1,0 +1,47 @@
+import styles from './OracleStrip.module.css'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface OracleStripProps {
+  tableId: string
+  roll: number
+  raw: string
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
+export function formatTableName(tableId: string): string {
+  // Compound tables use '+' separator in the id (e.g. "action+theme")
+  // Simple tables are kebab-case (e.g. "settlement-name")
+  const parts = tableId.split('+')
+  return parts
+    .map((part) => part.split('-').map(capitalize).join(' '))
+    .join(' + ')
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function OracleStrip({ tableId, roll, raw }: OracleStripProps) {
+  const formattedName = formatTableName(tableId)
+
+  return (
+    <div
+      className={styles.strip}
+      aria-label={`Oracle: ${formattedName} — ${raw}`}
+      data-testid="oracle-strip"
+    >
+      <span className={styles.icon} aria-hidden="true">
+        🎲
+      </span>
+      <div className={styles.content}>
+        <span className={styles.tableName}>{formattedName}</span>
+        <span className={styles.raw}>{raw}</span>
+        <span className={styles.roll}>{roll}</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.module.css
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.module.css
@@ -9,7 +9,7 @@
 
 /* ── FEED ITEM WRAPPER ── */
 .item {
-  display: contents;
+  display: block;
 }
 
 /* ── SKALD MESSAGE ── */

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.module.css
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.module.css
@@ -1,0 +1,169 @@
+.feed {
+  flex: 1;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+}
+
+/* ── FEED ITEM WRAPPER ── */
+.item {
+  display: contents;
+}
+
+/* ── SKALD MESSAGE ── */
+.skaldRow {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.skaldAvatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 3px;
+  background: var(--color-ember, #1e1710);
+  border: 1px solid rgba(212, 148, 26, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  line-height: 1;
+}
+
+.skaldBubble {
+  flex: 1;
+  background: var(--color-ash, #13100d);
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 0 4px 4px 4px;
+  padding: 12px 14px;
+  font-size: 11px;
+  color: var(--color-parchment, #c4a96e);
+  line-height: 1.8;
+  font-style: italic;
+  position: relative;
+}
+
+.skaldBubble::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(212, 148, 26, 0.4), transparent);
+}
+
+.skaldBubble.partial {
+  opacity: 0.8;
+}
+
+/* ── PLAYER MESSAGE ── */
+.playerRow {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.playerBubble {
+  max-width: 72%;
+  background: #1a130a;
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 4px 0 4px 4px;
+  padding: 10px 14px;
+  font-size: 11px;
+  color: var(--color-parchment, #c4a96e);
+  line-height: 1.7;
+}
+
+/* ── SYSTEM MESSAGE ── */
+.systemBubble {
+  background: rgba(212, 148, 26, 0.04);
+  border: 1px solid rgba(212, 148, 26, 0.12);
+  border-left: 3px solid rgba(212, 148, 26, 0.4);
+  border-radius: 0 4px 4px 0;
+  padding: 12px 14px;
+  font-size: 11px;
+  color: var(--color-parchment, #c4a96e);
+  line-height: 1.8;
+  font-style: italic;
+}
+
+/* ── TYPING INDICATOR ── */
+.typingIndicator {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.typingAvatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 3px;
+  background: var(--color-ember, #1e1710);
+  border: 1px solid rgba(212, 148, 26, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.typingDots {
+  display: flex;
+  gap: 4px;
+  padding: 8px 14px;
+  background: var(--color-ash, #13100d);
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 0 4px 4px 4px;
+}
+
+.dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-gold, #d4941a);
+  animation: pulse 1.4s infinite ease-in-out;
+}
+
+.dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ── ERROR BANNER ── */
+.errorBanner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(139, 26, 26, 0.1);
+  border: 1px solid rgba(139, 26, 26, 0.3);
+  border-radius: 3px;
+  font-size: 10px;
+  color: #c0392b;
+  letter-spacing: 1px;
+}
+
+.errorIcon {
+  font-size: 13px;
+}

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.test.tsx
@@ -78,6 +78,11 @@ describe('SkaldFeed — typing indicator', () => {
     expect(screen.getByRole('status')).toBeTruthy()
   })
 
+  it('shows typing indicator when phase is "move-pending"', () => {
+    renderFeed([], 'move-pending')
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
   it('hides typing indicator when phase is "idle"', () => {
     renderFeed([], 'idle')
     expect(screen.queryByRole('status')).toBeNull()

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { SkaldMessage, TurnPhase } from '@/store/types'
+import { SkaldFeed } from './SkaldFeed'
+
+function makeMessage(overrides: Partial<SkaldMessage>): SkaldMessage {
+  return {
+    id: 'msg-1',
+    role: 'skald',
+    content: 'Test content',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderFeed(
+  messages: SkaldMessage[] = [],
+  phase: TurnPhase = 'idle',
+  streamBuffer = '',
+) {
+  return render(<SkaldFeed messages={messages} phase={phase} streamBuffer={streamBuffer} />)
+}
+
+describe('SkaldFeed — structure', () => {
+  it('renders a log region with aria-live="polite"', () => {
+    renderFeed()
+    const log = screen.getByRole('log')
+    expect(log).toBeTruthy()
+    expect(log.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('renders nothing when messages is empty', () => {
+    renderFeed()
+    const log = screen.getByRole('log')
+    expect(log.querySelectorAll('[data-testid="skald-bubble"], [data-testid="player-bubble"]').length).toBe(0)
+  })
+
+  it('renders a skald message bubble with the content text', () => {
+    renderFeed([makeMessage({ role: 'skald', content: 'The ravens fly north.' })])
+    expect(screen.getByText('The ravens fly north.')).toBeTruthy()
+  })
+
+  it('renders a player message bubble with the content text', () => {
+    renderFeed([makeMessage({ role: 'player', content: 'I charge forward.' })])
+    expect(screen.getByText('I charge forward.')).toBeTruthy()
+  })
+
+  it('skald message avatar has aria-hidden="true"', () => {
+    renderFeed([makeMessage({ role: 'skald' })])
+    const log = screen.getByRole('log')
+    const avatar = log.querySelector('[data-testid="skald-avatar"]')
+    expect(avatar).toBeTruthy()
+    expect(avatar!.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('messages render oldest-first (top to bottom order)', () => {
+    const messages = [
+      makeMessage({ id: 'a', role: 'skald', content: 'First message' }),
+      makeMessage({ id: 'b', role: 'player', content: 'Second message' }),
+    ]
+    renderFeed(messages)
+    const log = screen.getByRole('log')
+    const items = log.querySelectorAll('[data-testid="feed-item"]')
+    expect(items.length).toBe(2)
+    expect(items[0]!.textContent).toContain('First message')
+    expect(items[1]!.textContent).toContain('Second message')
+  })
+})
+
+describe('SkaldFeed — typing indicator', () => {
+  it('shows typing indicator when phase is "waiting-for-ai"', () => {
+    renderFeed([], 'waiting-for-ai')
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('shows typing indicator when phase is "streaming"', () => {
+    renderFeed([], 'streaming')
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('hides typing indicator when phase is "idle"', () => {
+    renderFeed([], 'idle')
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('typing indicator has aria-label "The Skald is composing..."', () => {
+    renderFeed([], 'waiting-for-ai')
+    const indicator = screen.getByRole('status')
+    expect(indicator.getAttribute('aria-label')).toBe('The Skald is composing...')
+  })
+})
+
+describe('SkaldFeed — streaming', () => {
+  it('renders streamBuffer as a partial skald bubble when streaming', () => {
+    renderFeed([], 'streaming', 'The wind whispers...')
+    expect(screen.getByText('The wind whispers...')).toBeTruthy()
+  })
+
+  it('streamBuffer bubble absent when streamBuffer is empty', () => {
+    renderFeed([], 'streaming', '')
+    const log = screen.getByRole('log')
+    const partials = log.querySelectorAll('[data-testid="stream-bubble"]')
+    expect(partials.length).toBe(0)
+  })
+})
+
+describe('SkaldFeed — error state', () => {
+  it('shows error indicator when phase is "error"', () => {
+    renderFeed([], 'error')
+    expect(screen.getByRole('alert')).toBeTruthy()
+  })
+
+  it('hides error indicator when phase is not "error"', () => {
+    renderFeed([], 'idle')
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.test.tsx
@@ -109,6 +109,41 @@ describe('SkaldFeed — streaming', () => {
   })
 })
 
+describe('SkaldFeed — outcome messages', () => {
+  it('renders a MoveOutcomeCard for an outcome role message', () => {
+    const content = JSON.stringify({
+      moveId: 'face-danger',
+      moveName: 'Face Danger',
+      result: 'strong-hit',
+      match: false,
+      roll: null,
+      consequences: [],
+    })
+    renderFeed([makeMessage({ role: 'outcome', content })])
+    expect(screen.getByTestId('move-outcome-card')).toBeTruthy()
+    expect(screen.getByText('Face Danger')).toBeTruthy()
+  })
+
+  it('renders nothing when outcome content is invalid JSON', () => {
+    renderFeed([makeMessage({ role: 'outcome', content: 'not-json' })])
+    expect(screen.queryByTestId('move-outcome-card')).toBeNull()
+  })
+})
+
+describe('SkaldFeed — oracle messages', () => {
+  it('renders an OracleStrip for an oracle role message', () => {
+    const content = JSON.stringify({ tableId: 'theme', roll: 42, raw: 'Darkness' })
+    renderFeed([makeMessage({ role: 'oracle', content })])
+    expect(screen.getByTestId('oracle-strip')).toBeTruthy()
+    expect(screen.getByText('Darkness')).toBeTruthy()
+  })
+
+  it('renders nothing when oracle content is invalid JSON', () => {
+    renderFeed([makeMessage({ role: 'oracle', content: 'bad' })])
+    expect(screen.queryByTestId('oracle-strip')).toBeNull()
+  })
+})
+
 describe('SkaldFeed — error state', () => {
   it('shows error indicator when phase is "error"', () => {
     renderFeed([], 'error')

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
@@ -8,7 +8,7 @@ interface SkaldFeedProps {
 }
 
 export function SkaldFeed({ messages, phase, streamBuffer }: SkaldFeedProps) {
-  const isComposing = phase === 'waiting-for-ai' || phase === 'streaming'
+  const isComposing = phase === 'waiting-for-ai' || phase === 'streaming' || phase === 'move-pending'
   const hasError = phase === 'error'
 
   return (

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
@@ -102,6 +102,7 @@ function OutcomeItem({ content }: ContentProps) {
   } catch {
     return null
   }
+  if (!data || typeof data.moveId !== 'string') return null
   return <MoveOutcomeCard {...data} />
 }
 
@@ -112,5 +113,6 @@ function OracleItem({ content }: ContentProps) {
   } catch {
     return null
   }
+  if (!data || typeof data.tableId !== 'string') return null
   return <OracleStrip tableId={data.tableId} roll={data.roll} raw={data.raw} />
 }

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
@@ -1,4 +1,6 @@
 import type { SkaldMessage, TurnPhase } from '@/store/types'
+import { MoveOutcomeCard, type MoveOutcomeData } from '../MoveOutcomeCard/MoveOutcomeCard'
+import { OracleStrip } from '../OracleStrip/OracleStrip'
 import styles from './SkaldFeed.module.css'
 
 interface SkaldFeedProps {
@@ -18,6 +20,8 @@ export function SkaldFeed({ messages, phase, streamBuffer }: SkaldFeedProps) {
           {msg.role === 'skald' && <SkaldBubble content={msg.content} />}
           {msg.role === 'player' && <PlayerBubble content={msg.content} />}
           {msg.role === 'system' && <SystemBubble content={msg.content} />}
+          {msg.role === 'outcome' && <OutcomeItem content={msg.content} />}
+          {msg.role === 'oracle' && <OracleItem content={msg.content} />}
         </div>
       ))}
 
@@ -85,4 +89,28 @@ function SystemBubble({ content }: BubbleProps) {
       {content}
     </div>
   )
+}
+
+interface ContentProps {
+  content: string
+}
+
+function OutcomeItem({ content }: ContentProps) {
+  let data: MoveOutcomeData | null = null
+  try {
+    data = JSON.parse(content) as MoveOutcomeData
+  } catch {
+    return null
+  }
+  return <MoveOutcomeCard {...data} />
+}
+
+function OracleItem({ content }: ContentProps) {
+  let data: { tableId: string; roll: number; raw: string } | null = null
+  try {
+    data = JSON.parse(content) as { tableId: string; roll: number; raw: string }
+  } catch {
+    return null
+  }
+  return <OracleStrip tableId={data.tableId} roll={data.roll} raw={data.raw} />
 }

--- a/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
+++ b/apps/web/src/screens/skald/components/SkaldFeed/SkaldFeed.tsx
@@ -1,0 +1,88 @@
+import type { SkaldMessage, TurnPhase } from '@/store/types'
+import styles from './SkaldFeed.module.css'
+
+interface SkaldFeedProps {
+  messages: SkaldMessage[]
+  phase: TurnPhase
+  streamBuffer: string
+}
+
+export function SkaldFeed({ messages, phase, streamBuffer }: SkaldFeedProps) {
+  const isComposing = phase === 'waiting-for-ai' || phase === 'streaming'
+  const hasError = phase === 'error'
+
+  return (
+    <div className={styles.feed} role="log" aria-live="polite" aria-label="Story feed">
+      {messages.map((msg) => (
+        <div key={msg.id} className={styles.item} data-testid="feed-item">
+          {msg.role === 'skald' && <SkaldBubble content={msg.content} />}
+          {msg.role === 'player' && <PlayerBubble content={msg.content} />}
+          {msg.role === 'system' && <SystemBubble content={msg.content} />}
+        </div>
+      ))}
+
+      {phase === 'streaming' && streamBuffer !== '' && (
+        <div className={styles.item} data-testid="feed-item">
+          <SkaldBubble content={streamBuffer} partial data-testid="stream-bubble" />
+        </div>
+      )}
+
+      {isComposing && (
+        <div
+          className={styles.typingIndicator}
+          role="status"
+          aria-label="The Skald is composing..."
+        >
+          <span className={styles.typingAvatar} aria-hidden="true">🪶</span>
+          <div className={styles.typingDots}>
+            <span className={styles.dot} />
+            <span className={styles.dot} />
+            <span className={styles.dot} />
+          </div>
+        </div>
+      )}
+
+      {hasError && (
+        <div className={styles.errorBanner} role="alert">
+          <span className={styles.errorIcon} aria-hidden="true">⚠</span>
+          The Skald encountered an error. Please try again.
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface BubbleProps {
+  content: string
+  partial?: boolean
+  'data-testid'?: string
+}
+
+function SkaldBubble({ content, partial, 'data-testid': testId }: BubbleProps) {
+  return (
+    <div className={styles.skaldRow} data-testid={testId ?? 'skald-bubble'}>
+      <span className={styles.skaldAvatar} aria-hidden="true" data-testid="skald-avatar">
+        🪶
+      </span>
+      <div className={`${styles.skaldBubble} ${partial ? styles.partial : ''}`}>
+        {content}
+      </div>
+    </div>
+  )
+}
+
+function PlayerBubble({ content }: BubbleProps) {
+  return (
+    <div className={styles.playerRow} data-testid="player-bubble">
+      <div className={styles.playerBubble}>{content}</div>
+    </div>
+  )
+}
+
+function SystemBubble({ content }: BubbleProps) {
+  return (
+    <div className={styles.systemBubble} data-testid="system-bubble">
+      {content}
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.module.css
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.module.css
@@ -80,6 +80,26 @@
   cursor: not-allowed;
 }
 
+/* ── MOVES BUTTON ── */
+.movesBtn {
+  background: rgba(212, 148, 26, 0.06);
+  border: 1px solid rgba(212, 148, 26, 0.25);
+  border-radius: 3px;
+  padding: 8px 12px;
+  font-size: 14px;
+  color: var(--color-gold, #d4941a);
+  cursor: pointer;
+  transition: all 0.2s;
+  line-height: 1;
+}
+
+.movesBtn:hover,
+.movesBtn[aria-expanded='true'] {
+  background: rgba(212, 148, 26, 0.12);
+  border-color: rgba(212, 148, 26, 0.45);
+  color: var(--color-gold-bright, #f0b429);
+}
+
 /* ── ORACLE BUTTON ── */
 .oracleBtn {
   background: rgba(122, 179, 204, 0.06);

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.module.css
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.module.css
@@ -1,0 +1,125 @@
+.inputBar {
+  padding: 12px 20px;
+  border-top: 1px solid rgba(30, 23, 16, 1);
+  flex-shrink: 0;
+}
+
+/* ── QUICK MOVE PILLS ── */
+.pillList {
+  display: flex;
+  gap: 5px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 8px;
+}
+
+.pillItem {
+  display: contents;
+}
+
+.pill {
+  background: var(--color-ember, #1e1710);
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 20px;
+  padding: 3px 10px;
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--color-bone, #7a6a52);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.pill:hover {
+  border-color: rgba(212, 148, 26, 0.4);
+  color: var(--color-gold, #d4941a);
+  background: rgba(212, 148, 26, 0.08);
+}
+
+.pill[data-category='combat'] {
+  border-color: rgba(139, 26, 26, 0.35);
+  color: #c0392b;
+  background: rgba(139, 26, 26, 0.07);
+}
+
+.pill[data-category='combat']:hover {
+  border-color: rgba(192, 57, 43, 0.55);
+  background: rgba(139, 26, 26, 0.14);
+}
+
+/* ── INPUT ROW ── */
+.inputRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  background: var(--color-ash, #13100d);
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 3px;
+  padding: 9px 14px;
+  font-family: 'Cinzel', serif;
+  font-size: 11px;
+  color: var(--color-parchment, #c4a96e);
+  letter-spacing: 1px;
+  transition: border-color 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(212, 148, 26, 0.5);
+}
+
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── ORACLE BUTTON ── */
+.oracleBtn {
+  background: rgba(122, 179, 204, 0.06);
+  border: 1px solid rgba(122, 179, 204, 0.25);
+  border-radius: 3px;
+  padding: 8px 12px;
+  font-size: 15px;
+  color: #7ab3cc;
+  cursor: pointer;
+  transition: all 0.2s;
+  line-height: 1;
+}
+
+.oracleBtn:hover,
+.oracleBtn[aria-expanded='true'] {
+  background: rgba(122, 179, 204, 0.12);
+  border-color: rgba(122, 179, 204, 0.45);
+  color: #a8d4e8;
+}
+
+/* ── SEND BUTTON ── */
+.sendBtn {
+  background: linear-gradient(135deg, rgba(139, 26, 26, 0.75), rgba(192, 57, 43, 0.55));
+  border: 1px solid rgba(192, 57, 43, 0.45);
+  border-radius: 3px;
+  padding: 8px 16px;
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: var(--color-parchment, #c4a96e);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.sendBtn:hover:not(:disabled) {
+  background: linear-gradient(135deg, rgba(192, 57, 43, 0.85), rgba(220, 80, 60, 0.7));
+  border-color: rgba(220, 80, 60, 0.6);
+}
+
+.sendBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
@@ -203,6 +203,26 @@ describe('SkaldInputBar — input interaction', () => {
     const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
     expect(input.disabled).toBe(true)
   })
+
+  it('input is disabled when phase is "resolving"', () => {
+    renderBar({ phase: 'resolving' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
+    expect(input.disabled).toBe(true)
+  })
+
+  it('Send button is disabled when phase is "resolving"', () => {
+    renderBar({ phase: 'resolving' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i }) as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(true)
+  })
+
+  it('pill buttons are disabled when phase is "resolving"', () => {
+    renderBar({ phase: 'resolving', moves: [makeMove()] })
+    const pill = screen.getByRole('button', { name: /face a threat/i }) as HTMLButtonElement
+    expect(pill.disabled).toBe(true)
+  })
 })
 
 describe('SkaldInputBar — oracle button', () => {

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
@@ -23,6 +23,8 @@ const defaultProps = {
   onMoveSelect: vi.fn(),
   onOracleOpen: vi.fn(),
   isOracleOpen: false,
+  onMovesOpen: vi.fn(),
+  isMovesOpen: false,
 }
 
 function renderBar(overrides: Partial<typeof defaultProps> = {}) {

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
@@ -39,9 +39,9 @@ describe('SkaldInputBar — structure', () => {
     expect(screen.getByRole('textbox', { name: /tell the skald what you do/i })).toBeTruthy()
   })
 
-  it('renders Send button type="button" with aria-label "Send"', () => {
+  it('renders Speak button type="button"', () => {
     renderBar()
-    const sendBtn = screen.getByRole('button', { name: /^send$/i })
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i })
     expect(sendBtn.getAttribute('type')).toBe('button')
   })
 
@@ -89,6 +89,24 @@ describe('SkaldInputBar — quick move pills', () => {
     const pill = screen.getByRole('button', { name: /face a threat/i })
     expect(pill.getAttribute('type')).toBe('button')
   })
+
+  it('pill buttons are disabled when phase is "waiting-for-ai"', () => {
+    renderBar({ phase: 'waiting-for-ai', moves: [makeMove()] })
+    const pill = screen.getByRole('button', { name: /face a threat/i }) as HTMLButtonElement
+    expect(pill.disabled).toBe(true)
+  })
+
+  it('pill buttons are disabled when phase is "move-pending"', () => {
+    renderBar({ phase: 'move-pending', moves: [makeMove()] })
+    const pill = screen.getByRole('button', { name: /face a threat/i }) as HTMLButtonElement
+    expect(pill.disabled).toBe(true)
+  })
+
+  it('pill buttons are enabled when phase is "idle"', () => {
+    renderBar({ phase: 'idle', moves: [makeMove()] })
+    const pill = screen.getByRole('button', { name: /face a threat/i }) as HTMLButtonElement
+    expect(pill.disabled).toBe(false)
+  })
 })
 
 describe('SkaldInputBar — input interaction', () => {
@@ -130,13 +148,13 @@ describe('SkaldInputBar — input interaction', () => {
     renderBar({ onSend })
     const input = screen.getByRole('textbox', { name: /tell the skald/i })
     fireEvent.change(input, { target: { value: 'Hello Skald' } })
-    fireEvent.click(screen.getByRole('button', { name: /^send$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^speak$/i }))
     expect(onSend).toHaveBeenCalledWith('Hello Skald')
   })
 
   it('Send button is disabled when input is empty', () => {
     renderBar()
-    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i }) as HTMLButtonElement
     expect(sendBtn.disabled).toBe(true)
   })
 
@@ -144,7 +162,7 @@ describe('SkaldInputBar — input interaction', () => {
     renderBar()
     const input = screen.getByRole('textbox', { name: /tell the skald/i })
     fireEvent.change(input, { target: { value: 'Hello' } })
-    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i }) as HTMLButtonElement
     expect(sendBtn.disabled).toBe(false)
   })
 
@@ -152,7 +170,7 @@ describe('SkaldInputBar — input interaction', () => {
     renderBar({ phase: 'waiting-for-ai' })
     const input = screen.getByRole('textbox', { name: /tell the skald/i })
     fireEvent.change(input, { target: { value: 'Hello' } })
-    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i }) as HTMLButtonElement
     expect(sendBtn.disabled).toBe(true)
   })
 
@@ -160,12 +178,26 @@ describe('SkaldInputBar — input interaction', () => {
     renderBar({ phase: 'streaming' })
     const input = screen.getByRole('textbox', { name: /tell the skald/i })
     fireEvent.change(input, { target: { value: 'Hello' } })
-    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i }) as HTMLButtonElement
     expect(sendBtn.disabled).toBe(true)
   })
 
   it('input is disabled when phase is "waiting-for-ai"', () => {
     renderBar({ phase: 'waiting-for-ai' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
+    expect(input.disabled).toBe(true)
+  })
+
+  it('Send button is disabled when phase is "move-pending"', () => {
+    renderBar({ phase: 'move-pending' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    const sendBtn = screen.getByRole('button', { name: /^speak$/i }) as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(true)
+  })
+
+  it('input is disabled when phase is "move-pending"', () => {
+    renderBar({ phase: 'move-pending' })
     const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
     expect(input.disabled).toBe(true)
   })

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { Move } from '@saga-keeper/domain'
+import type { TurnPhase } from '@/store/types'
+import { SkaldInputBar } from './SkaldInputBar'
+
+function makeMove(overrides: Partial<Move> = {}): Move {
+  return {
+    id: 'face-danger',
+    name: 'Face Danger',
+    trigger: 'Face a threat',
+    category: 'adventure',
+    stats: ['edge', 'heart', 'iron', 'shadow', 'wits'],
+    description: 'When you attempt something risky...',
+    ...overrides,
+  }
+}
+
+const defaultProps = {
+  phase: 'idle' as TurnPhase,
+  moves: [makeMove()],
+  onSend: vi.fn(),
+  onMoveSelect: vi.fn(),
+  onOracleOpen: vi.fn(),
+  isOracleOpen: false,
+}
+
+function renderBar(overrides: Partial<typeof defaultProps> = {}) {
+  return render(<SkaldInputBar {...defaultProps} {...overrides} />)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('SkaldInputBar — structure', () => {
+  it('renders input with aria-label "Tell the Skald what you do"', () => {
+    renderBar()
+    expect(screen.getByRole('textbox', { name: /tell the skald what you do/i })).toBeTruthy()
+  })
+
+  it('renders Send button type="button" with aria-label "Send"', () => {
+    renderBar()
+    const sendBtn = screen.getByRole('button', { name: /^send$/i })
+    expect(sendBtn.getAttribute('type')).toBe('button')
+  })
+
+  it('renders quick-moves list role="list" aria-label="Quick moves"', () => {
+    renderBar()
+    expect(screen.getByRole('list', { name: /quick moves/i })).toBeTruthy()
+  })
+
+  it('renders listitem per move pill', () => {
+    const moves = [makeMove({ id: 'a', trigger: 'Move A' }), makeMove({ id: 'b', trigger: 'Move B' })]
+    renderBar({ moves })
+    const list = screen.getByRole('list', { name: /quick moves/i })
+    expect(list.querySelectorAll('[role="listitem"]').length).toBe(2)
+  })
+})
+
+describe('SkaldInputBar — quick move pills', () => {
+  it('renders pill buttons from moves prop', () => {
+    renderBar({ moves: [makeMove({ trigger: 'Face Danger' })] })
+    expect(screen.getByRole('button', { name: /face danger/i })).toBeTruthy()
+  })
+
+  it('combat move pills have data-category="combat"', () => {
+    const moves = [makeMove({ id: 'strike', trigger: 'Strike', category: 'combat' })]
+    renderBar({ moves })
+    const pill = screen.getByRole('button', { name: /strike/i })
+    expect(pill.getAttribute('data-category')).toBe('combat')
+  })
+
+  it('non-combat pills do not have data-category="combat"', () => {
+    renderBar({ moves: [makeMove({ category: 'adventure' })] })
+    const pill = screen.getByRole('button', { name: /face a threat/i })
+    expect(pill.getAttribute('data-category')).not.toBe('combat')
+  })
+
+  it('clicking a pill calls onMoveSelect with move id', () => {
+    const onMoveSelect = vi.fn()
+    renderBar({ moves: [makeMove({ id: 'face-danger' })], onMoveSelect })
+    fireEvent.click(screen.getByRole('button', { name: /face a threat/i }))
+    expect(onMoveSelect).toHaveBeenCalledWith('face-danger')
+  })
+
+  it('each pill button has type="button"', () => {
+    renderBar({ moves: [makeMove()] })
+    const pill = screen.getByRole('button', { name: /face a threat/i })
+    expect(pill.getAttribute('type')).toBe('button')
+  })
+})
+
+describe('SkaldInputBar — input interaction', () => {
+  it('typing in the input updates the displayed value', () => {
+    renderBar()
+    const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'I draw my sword' } })
+    expect(input.value).toBe('I draw my sword')
+  })
+
+  it('pressing Enter calls onSend with the input text', () => {
+    const onSend = vi.fn()
+    renderBar({ onSend })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Forward!' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+    expect(onSend).toHaveBeenCalledWith('Forward!')
+  })
+
+  it('pressing Enter clears the input after send', () => {
+    renderBar()
+    const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Some text' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+    expect(input.value).toBe('')
+  })
+
+  it('pressing Shift+Enter does not call onSend', () => {
+    const onSend = vi.fn()
+    renderBar({ onSend })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Some text' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('clicking Send calls onSend with the input text', () => {
+    const onSend = vi.fn()
+    renderBar({ onSend })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Hello Skald' } })
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }))
+    expect(onSend).toHaveBeenCalledWith('Hello Skald')
+  })
+
+  it('Send button is disabled when input is empty', () => {
+    renderBar()
+    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(true)
+  })
+
+  it('Send button is enabled when input has text', () => {
+    renderBar()
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(false)
+  })
+
+  it('Send button is disabled when phase is "waiting-for-ai"', () => {
+    renderBar({ phase: 'waiting-for-ai' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(true)
+  })
+
+  it('Send button is disabled when phase is "streaming"', () => {
+    renderBar({ phase: 'streaming' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i })
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    const sendBtn = screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(true)
+  })
+
+  it('input is disabled when phase is "waiting-for-ai"', () => {
+    renderBar({ phase: 'waiting-for-ai' })
+    const input = screen.getByRole('textbox', { name: /tell the skald/i }) as HTMLInputElement
+    expect(input.disabled).toBe(true)
+  })
+})
+
+describe('SkaldInputBar — oracle button', () => {
+  it('renders Oracle button with aria-label "Open oracle"', () => {
+    renderBar()
+    expect(screen.getByRole('button', { name: /open oracle/i })).toBeTruthy()
+  })
+
+  it('clicking Oracle button calls onOracleOpen', () => {
+    const onOracleOpen = vi.fn()
+    renderBar({ onOracleOpen })
+    fireEvent.click(screen.getByRole('button', { name: /open oracle/i }))
+    expect(onOracleOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('Oracle button has aria-expanded="false" when popover is closed', () => {
+    renderBar({ isOracleOpen: false })
+    const oracleBtn = screen.getByRole('button', { name: /open oracle/i })
+    expect(oracleBtn.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('Oracle button has aria-expanded="true" when popover is open', () => {
+    renderBar({ isOracleOpen: true })
+    const oracleBtn = screen.getByRole('button', { name: /open oracle/i })
+    expect(oracleBtn.getAttribute('aria-expanded')).toBe('true')
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
@@ -26,7 +26,7 @@ export function SkaldInputBar({
 }: SkaldInputBarProps) {
   const [text, setText] = useState('')
 
-  const isBusy = phase === 'waiting-for-ai' || phase === 'streaming' || phase === 'move-pending'
+  const isBusy = phase === 'resolving' || phase === 'waiting-for-ai' || phase === 'streaming' || phase === 'move-pending'
   const canSend = text.trim().length > 0 && !isBusy
 
   function handleSend() {

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
@@ -10,6 +10,8 @@ interface SkaldInputBarProps {
   onMoveSelect: (moveId: string) => void
   onOracleOpen: () => void
   isOracleOpen: boolean
+  onMovesOpen: () => void
+  isMovesOpen: boolean
 }
 
 export function SkaldInputBar({
@@ -19,6 +21,8 @@ export function SkaldInputBar({
   onMoveSelect,
   onOracleOpen,
   isOracleOpen,
+  onMovesOpen,
+  isMovesOpen,
 }: SkaldInputBarProps) {
   const [text, setText] = useState('')
 
@@ -67,6 +71,17 @@ export function SkaldInputBar({
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
         />
+        <button
+          type="button"
+          className={styles.movesBtn}
+          aria-label="Open move browser"
+          aria-haspopup="dialog"
+          aria-expanded={isMovesOpen}
+          aria-controls="skald-moves-popover"
+          onClick={onMovesOpen}
+        >
+          ⚔
+        </button>
         <button
           type="button"
           className={styles.oracleBtn}

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
@@ -22,7 +22,7 @@ export function SkaldInputBar({
 }: SkaldInputBarProps) {
   const [text, setText] = useState('')
 
-  const isBusy = phase === 'waiting-for-ai' || phase === 'streaming'
+  const isBusy = phase === 'waiting-for-ai' || phase === 'streaming' || phase === 'move-pending'
   const canSend = text.trim().length > 0 && !isBusy
 
   function handleSend() {
@@ -47,6 +47,7 @@ export function SkaldInputBar({
               type="button"
               className={styles.pill}
               data-category={move.category}
+              disabled={isBusy}
               onClick={() => onMoveSelect(move.id)}
             >
               {move.trigger}
@@ -80,7 +81,6 @@ export function SkaldInputBar({
         <button
           type="button"
           className={styles.sendBtn}
-          aria-label="Send"
           disabled={!canSend}
           onClick={handleSend}
         >

--- a/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
+++ b/apps/web/src/screens/skald/components/SkaldInputBar/SkaldInputBar.tsx
@@ -1,0 +1,92 @@
+import { useState, type KeyboardEvent } from 'react'
+import type { Move } from '@saga-keeper/domain'
+import type { TurnPhase } from '@/store/types'
+import styles from './SkaldInputBar.module.css'
+
+interface SkaldInputBarProps {
+  phase: TurnPhase
+  moves: Move[]
+  onSend: (text: string) => void
+  onMoveSelect: (moveId: string) => void
+  onOracleOpen: () => void
+  isOracleOpen: boolean
+}
+
+export function SkaldInputBar({
+  phase,
+  moves,
+  onSend,
+  onMoveSelect,
+  onOracleOpen,
+  isOracleOpen,
+}: SkaldInputBarProps) {
+  const [text, setText] = useState('')
+
+  const isBusy = phase === 'waiting-for-ai' || phase === 'streaming'
+  const canSend = text.trim().length > 0 && !isBusy
+
+  function handleSend() {
+    if (!canSend) return
+    onSend(text.trim())
+    setText('')
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  return (
+    <div className={styles.inputBar}>
+      <ul className={styles.pillList} role="list" aria-label="Quick moves">
+        {moves.map((move) => (
+          <li key={move.id} role="listitem" className={styles.pillItem}>
+            <button
+              type="button"
+              className={styles.pill}
+              data-category={move.category}
+              onClick={() => onMoveSelect(move.id)}
+            >
+              {move.trigger}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className={styles.inputRow}>
+        <input
+          className={styles.input}
+          type="text"
+          aria-label="Tell the Skald what you do"
+          placeholder="What do you do..."
+          value={text}
+          disabled={isBusy}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          type="button"
+          className={styles.oracleBtn}
+          aria-label="Open oracle"
+          aria-haspopup="dialog"
+          aria-expanded={isOracleOpen}
+          aria-controls="skald-oracle-popover"
+          onClick={onOracleOpen}
+        >
+          ᛟ
+        </button>
+        <button
+          type="button"
+          className={styles.sendBtn}
+          aria-label="Send"
+          disabled={!canSend}
+          onClick={handleSend}
+        >
+          Speak
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.module.css
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.module.css
@@ -1,0 +1,133 @@
+.charCard {
+  margin: 0 0 12px;
+  background: var(--color-ash, #13100d);
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 3px;
+  padding: 10px;
+}
+
+.charName {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 12px;
+  color: var(--color-gold-bright, #f0b429);
+  margin: 0 0 2px;
+}
+
+.charEpithet {
+  font-size: 8px;
+  letter-spacing: 2px;
+  color: var(--color-stone, #5f5447);
+  text-transform: uppercase;
+  margin: 0 0 8px;
+}
+
+.noChar {
+  font-size: 9px;
+  color: var(--color-stone, #5f5447);
+  font-style: italic;
+  margin: 0;
+}
+
+/* ── STAT BARS ── */
+.statBars {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.statBarRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.statBarLabel {
+  font-size: 8px;
+  letter-spacing: 1px;
+  color: var(--color-stone, #5f5447);
+  text-transform: uppercase;
+  width: 26px;
+  flex-shrink: 0;
+}
+
+.statBarTrack {
+  flex: 1;
+  height: 6px;
+  background: rgba(30, 23, 16, 0.8);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.statBarFill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.statBarFill.health {
+  background: #8b1a1a;
+}
+
+.statBarFill.spirit {
+  background: #4a7a8a;
+}
+
+.statBarFill.momentum {
+  background: #5a8fa0;
+}
+
+.statBarNum {
+  font-size: 8px;
+  color: var(--color-stone, #5f5447);
+  width: 14px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ── SESSION SECTION ── */
+.sessionSection {
+  flex: 1;
+}
+
+.sectionLabel {
+  font-size: 8px;
+  letter-spacing: 4px;
+  color: var(--color-iron, #3d3428);
+  text-transform: uppercase;
+  padding: 0 8px;
+  margin: 12px 0 5px;
+}
+
+.sessionList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sessionItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 3px;
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--color-bone, #7a6a52);
+  border: 1px solid transparent;
+  margin-bottom: 2px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.sessionItem[aria-current='true'] {
+  color: var(--color-gold, #d4941a);
+  border-color: rgba(212, 148, 26, 0.25);
+  background: rgba(212, 148, 26, 0.08);
+}
+
+.sessionIcon {
+  font-size: 13px;
+  width: 18px;
+  text-align: center;
+}

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.module.css
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.module.css
@@ -120,7 +120,7 @@
   transition: all 0.15s;
 }
 
-.sessionItem[aria-current='true'] {
+.sessionItemActive {
   color: var(--color-gold, #d4941a);
   border-color: rgba(212, 148, 26, 0.25);
   background: rgba(212, 148, 26, 0.08);

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
@@ -76,7 +76,7 @@ describe('SkaldLeftSidebar — session list', () => {
     expect(screen.getByText(/current session/i)).toBeTruthy()
   })
 
-  it('current session item does not carry aria-current (visual-only active state)', () => {
+  it('active session item uses CSS class for visual state, not aria-current (aria-current is for navigation landmarks)', () => {
     render(<SkaldLeftSidebar character={null} />)
     const currentItem = screen.getByText(/current session/i).closest('li')
     expect(currentItem?.getAttribute('aria-current')).toBeNull()

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ironswornPlugin, type IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
+import type { CharacterState } from '@saga-keeper/domain'
+import { SkaldLeftSidebar } from './SkaldLeftSidebar'
+
+function makeCharacter(overrides: Partial<IronswornCharacterData> = {}): CharacterState {
+  const data = { ...ironswornPlugin.character.defaults(), ...overrides }
+  return {
+    id: 'char-1',
+    campaignId: 'camp-1',
+    name: 'Björn Ashclaw',
+    epithet: 'Warden · Dangerous',
+    rulesetId: 'ironsworn-v1',
+    data: data as Record<string, unknown>,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+describe('SkaldLeftSidebar — no character', () => {
+  it('renders placeholder when character is null', () => {
+    render(<SkaldLeftSidebar character={null} />)
+    expect(screen.getByText(/no character/i)).toBeTruthy()
+  })
+
+  it('does not render stat bars when character is null', () => {
+    render(<SkaldLeftSidebar character={null} />)
+    expect(screen.queryByRole('meter', { name: /health/i })).toBeNull()
+  })
+})
+
+describe('SkaldLeftSidebar — character card', () => {
+  it('renders character name', () => {
+    render(<SkaldLeftSidebar character={makeCharacter()} />)
+    expect(screen.getByText('Björn Ashclaw')).toBeTruthy()
+  })
+
+  it('renders epithet below name', () => {
+    render(<SkaldLeftSidebar character={makeCharacter()} />)
+    expect(screen.getByText('Warden · Dangerous')).toBeTruthy()
+  })
+
+  it('renders health bar with aria-label "Health"', () => {
+    render(<SkaldLeftSidebar character={makeCharacter({ health: 4 })} />)
+    expect(screen.getByRole('meter', { name: /health/i })).toBeTruthy()
+  })
+
+  it('renders spirit bar with aria-label "Spirit"', () => {
+    render(<SkaldLeftSidebar character={makeCharacter({ spirit: 3 })} />)
+    expect(screen.getByRole('meter', { name: /spirit/i })).toBeTruthy()
+  })
+
+  it('renders momentum bar with aria-label "Momentum"', () => {
+    render(<SkaldLeftSidebar character={makeCharacter({ momentum: 2 })} />)
+    expect(screen.getByRole('meter', { name: /momentum/i })).toBeTruthy()
+  })
+
+  it('health bar aria-valuenow reflects current health', () => {
+    render(<SkaldLeftSidebar character={makeCharacter({ health: 3 })} />)
+    const meter = screen.getByRole('meter', { name: /health/i })
+    expect(meter.getAttribute('aria-valuenow')).toBe('3')
+  })
+
+  it('renders numeric health label', () => {
+    render(<SkaldLeftSidebar character={makeCharacter({ health: 4 })} />)
+    // Health value label is shown next to the bar
+    const healthSection = screen.getByRole('meter', { name: /health/i }).closest('[data-testid="stat-bar-health"]')
+    expect(healthSection?.textContent).toContain('4')
+  })
+})
+
+describe('SkaldLeftSidebar — session list', () => {
+  it('renders "Current Session" heading', () => {
+    render(<SkaldLeftSidebar character={null} />)
+    expect(screen.getByText(/current session/i)).toBeTruthy()
+  })
+
+  it('current session item has aria-current="true"', () => {
+    render(<SkaldLeftSidebar character={null} />)
+    const currentItem = screen.getByText(/current session/i).closest('li')
+    expect(currentItem?.getAttribute('aria-current')).toBe('true')
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
@@ -76,9 +76,9 @@ describe('SkaldLeftSidebar — session list', () => {
     expect(screen.getByText(/current session/i)).toBeTruthy()
   })
 
-  it('current session item has aria-current="true"', () => {
+  it('current session item does not carry aria-current (visual-only active state)', () => {
     render(<SkaldLeftSidebar character={null} />)
     const currentItem = screen.getByText(/current session/i).closest('li')
-    expect(currentItem?.getAttribute('aria-current')).toBe('true')
+    expect(currentItem?.getAttribute('aria-current')).toBeNull()
   })
 })

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.test.tsx
@@ -76,7 +76,7 @@ describe('SkaldLeftSidebar — session list', () => {
     expect(screen.getByText(/current session/i)).toBeTruthy()
   })
 
-  it('active session item uses CSS class for visual state, not aria-current (aria-current is for navigation landmarks)', () => {
+  it('active session item uses CSS class for visual state, not aria-current', () => {
     render(<SkaldLeftSidebar character={null} />)
     const currentItem = screen.getByText(/current session/i).closest('li')
     expect(currentItem?.getAttribute('aria-current')).toBeNull()

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.tsx
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.tsx
@@ -36,7 +36,7 @@ export function SkaldLeftSidebar({ character }: SkaldLeftSidebarProps) {
       <section className={styles.sessionSection} aria-label="Sessions">
         <h3 className={styles.sectionLabel}>Sessions</h3>
         <ul className={styles.sessionList}>
-          <li className={styles.sessionItem} aria-current="true">
+          <li className={`${styles.sessionItem} ${styles.sessionItemActive}`}>
             <span className={styles.sessionIcon} aria-hidden="true">🔥</span>
             Current Session
           </li>
@@ -53,9 +53,16 @@ interface StatBarProps {
   max: number
 }
 
+const STAT_FILL_CLASS: Record<string, string | undefined> = {
+  health: styles.health,
+  spirit: styles.spirit,
+  momentum: styles.momentum,
+}
+
 function StatBar({ label, value, min, max }: StatBarProps) {
   const pct = Math.round(((value - min) / (max - min)) * 100)
   const clampedPct = Math.max(0, Math.min(100, pct))
+  const fillClass = STAT_FILL_CLASS[label.toLowerCase()] ?? ''
 
   return (
     <div className={styles.statBarRow} data-testid={`stat-bar-${label.toLowerCase()}`}>
@@ -68,7 +75,7 @@ function StatBar({ label, value, min, max }: StatBarProps) {
         aria-valuemin={min}
         aria-valuemax={max}
       >
-        <div className={`${styles.statBarFill} ${styles[label.toLowerCase() as 'health' | 'spirit' | 'momentum']}`} style={{ width: `${clampedPct}%` }} />
+        <div className={`${styles.statBarFill} ${fillClass}`} style={{ width: `${clampedPct}%` }} />
       </div>
       <span className={styles.statBarNum}>{value}</span>
     </div>

--- a/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.tsx
+++ b/apps/web/src/screens/skald/components/SkaldLeftSidebar/SkaldLeftSidebar.tsx
@@ -1,0 +1,76 @@
+import type { CharacterState } from '@saga-keeper/domain'
+import type { IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
+import styles from './SkaldLeftSidebar.module.css'
+
+interface SkaldLeftSidebarProps {
+  character: CharacterState | null
+}
+
+export function SkaldLeftSidebar({ character }: SkaldLeftSidebarProps) {
+  const data = character
+    ? (character.data as unknown as IronswornCharacterData)
+    : null
+
+  return (
+    <>
+      {/* Character card */}
+      <div className={styles.charCard}>
+        {character && data ? (
+          <>
+            <h2 className={styles.charName}>{character.name}</h2>
+            {character.epithet && (
+              <p className={styles.charEpithet}>{character.epithet}</p>
+            )}
+            <div className={styles.statBars}>
+              <StatBar label="Health" value={data.health} min={0} max={5} />
+              <StatBar label="Spirit" value={data.spirit} min={0} max={5} />
+              <StatBar label="Momentum" value={data.momentum} min={-6} max={10} />
+            </div>
+          </>
+        ) : (
+          <p className={styles.noChar}>No character loaded</p>
+        )}
+      </div>
+
+      {/* Session list */}
+      <section className={styles.sessionSection} aria-label="Sessions">
+        <h3 className={styles.sectionLabel}>Sessions</h3>
+        <ul className={styles.sessionList}>
+          <li className={styles.sessionItem} aria-current="true">
+            <span className={styles.sessionIcon} aria-hidden="true">🔥</span>
+            Current Session
+          </li>
+        </ul>
+      </section>
+    </>
+  )
+}
+
+interface StatBarProps {
+  label: string
+  value: number
+  min: number
+  max: number
+}
+
+function StatBar({ label, value, min, max }: StatBarProps) {
+  const pct = Math.round(((value - min) / (max - min)) * 100)
+  const clampedPct = Math.max(0, Math.min(100, pct))
+
+  return (
+    <div className={styles.statBarRow} data-testid={`stat-bar-${label.toLowerCase()}`}>
+      <span className={styles.statBarLabel}>{label.slice(0, 2).toUpperCase()}</span>
+      <div
+        className={styles.statBarTrack}
+        role="meter"
+        aria-label={label}
+        aria-valuenow={value}
+        aria-valuemin={min}
+        aria-valuemax={max}
+      >
+        <div className={`${styles.statBarFill} ${styles[label.toLowerCase() as 'health' | 'spirit' | 'momentum']}`} style={{ width: `${clampedPct}%` }} />
+      </div>
+      <span className={styles.statBarNum}>{value}</span>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.module.css
@@ -1,8 +1,8 @@
 .popover {
-  position: absolute;
-  bottom: 100%;
-  right: 60px;
-  margin-bottom: 6px;
+  position: fixed;
+  bottom: 80px;
+  right: 280px;
+  margin-bottom: 0;
   width: 380px;
   background: var(--color-ash, #13100d);
   border: 1px solid rgba(212, 148, 26, 0.25);

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.module.css
@@ -1,0 +1,145 @@
+.popover {
+  position: absolute;
+  bottom: 100%;
+  right: 60px;
+  margin-bottom: 6px;
+  width: 380px;
+  background: var(--color-ash, #13100d);
+  border: 1px solid rgba(212, 148, 26, 0.25);
+  border-radius: 4px;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.6);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  max-height: 500px;
+}
+
+/* ── HEADER ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px 8px 16px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.15);
+  flex-shrink: 0;
+}
+
+.title {
+  font-family: 'Cinzel', serif;
+  font-size: 9px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--color-gold, #d4941a);
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  color: var(--color-bone, #7a6a52);
+  padding: 4px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.closeBtn:hover {
+  color: var(--color-parchment, #c4a96e);
+}
+
+/* ── BODY ── */
+.body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 8px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ── CATEGORY ── */
+.categoryHeading {
+  font-family: 'Cinzel', serif;
+  font-size: 7px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--color-stone, #5f5447);
+  margin: 0 0 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.1);
+}
+
+.moveList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* ── MOVE BUTTON ── */
+.moveBtn {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  padding: 6px 8px;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px 8px;
+  transition: all 0.15s;
+}
+
+.moveBtn:hover:not(:disabled) {
+  background: rgba(212, 148, 26, 0.06);
+  border-color: rgba(212, 148, 26, 0.2);
+}
+
+.moveBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.moveName {
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: var(--color-parchment, #c4a96e);
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.moveStats {
+  font-family: 'Cinzel', serif;
+  font-size: 7px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--color-stone, #5f5447);
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
+  white-space: nowrap;
+}
+
+.moveTrigger {
+  font-size: 9px;
+  color: var(--color-bone, #7a6a52);
+  font-style: italic;
+  line-height: 1.4;
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+
+/* Combat moves get a red tint */
+.moveBtn[data-category='combat']:hover:not(:disabled) {
+  background: rgba(139, 26, 26, 0.08);
+  border-color: rgba(192, 57, 43, 0.25);
+}
+
+.moveBtn[data-category='combat'] .moveName {
+  color: #c87272;
+}

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.module.css
@@ -1,7 +1,7 @@
 .popover {
   position: fixed;
   bottom: 80px;
-  right: 280px;
+  right: var(--right-panel-width, 280px);
   margin-bottom: 0;
   width: 380px;
   background: var(--color-ash, #13100d);

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.test.tsx
@@ -1,6 +1,18 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SkaldMovesPopover } from './SkaldMovesPopover'
+
+let rootEl: HTMLDivElement
+
+beforeEach(() => {
+  rootEl = document.createElement('div')
+  rootEl.id = 'root'
+  document.body.appendChild(rootEl)
+})
+
+afterEach(() => {
+  document.body.removeChild(rootEl)
+})
 
 function renderPopover(overrides: Partial<Parameters<typeof SkaldMovesPopover>[0]> = {}) {
   const props = {
@@ -102,5 +114,22 @@ describe('SkaldMovesPopover — interaction', () => {
 
     expect(document.activeElement).toBe(trigger)
     document.body.removeChild(trigger)
+  })
+})
+
+describe('SkaldMovesPopover — inert background', () => {
+  it('sets inert on #root when open', () => {
+    renderPopover({ isOpen: true })
+    expect(document.getElementById('root')?.hasAttribute('inert')).toBe(true)
+  })
+
+  it('removes inert from #root when closed', () => {
+    const { rerender } = render(
+      <SkaldMovesPopover isOpen isBusy={false} onClose={vi.fn()} onMoveSelect={vi.fn()} />,
+    )
+    rerender(
+      <SkaldMovesPopover isOpen={false} isBusy={false} onClose={vi.fn()} onMoveSelect={vi.fn()} />,
+    )
+    expect(document.getElementById('root')?.hasAttribute('inert')).toBe(false)
   })
 })

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SkaldMovesPopover } from './SkaldMovesPopover'
+
+function renderPopover(overrides: Partial<Parameters<typeof SkaldMovesPopover>[0]> = {}) {
+  const props = {
+    isOpen: true,
+    isBusy: false,
+    onClose: vi.fn(),
+    onMoveSelect: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<SkaldMovesPopover {...props} />), props }
+}
+
+describe('SkaldMovesPopover — visibility', () => {
+  it('renders nothing when isOpen is false', () => {
+    render(
+      <SkaldMovesPopover
+        isOpen={false}
+        isBusy={false}
+        onClose={vi.fn()}
+        onMoveSelect={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders a dialog when isOpen is true', () => {
+    renderPopover()
+    expect(screen.getByRole('dialog', { name: /move browser/i })).toBeTruthy()
+  })
+})
+
+describe('SkaldMovesPopover — structure', () => {
+  it('renders all 5 category sections', () => {
+    renderPopover()
+    expect(screen.getByRole('region', { name: /adventure/i })).toBeTruthy()
+    expect(screen.getByRole('region', { name: /combat/i })).toBeTruthy()
+    expect(screen.getByRole('region', { name: /quest/i })).toBeTruthy()
+    expect(screen.getByRole('region', { name: /relationship/i })).toBeTruthy()
+    expect(screen.getByRole('region', { name: /fate/i })).toBeTruthy()
+  })
+
+  it('renders move buttons inside the dialog', () => {
+    renderPopover()
+    const dialog = screen.getByRole('dialog')
+    const btns = dialog.querySelectorAll('button:not([aria-label="Close move browser"])')
+    expect(btns.length).toBeGreaterThan(0)
+  })
+})
+
+describe('SkaldMovesPopover — interaction', () => {
+  it('calls onMoveSelect and onClose when a move is clicked', () => {
+    const { props } = renderPopover()
+    const dialog = screen.getByRole('dialog')
+    const firstMoveBtn = dialog.querySelector(
+      'button:not([aria-label="Close move browser"])',
+    ) as HTMLButtonElement
+    fireEvent.click(firstMoveBtn)
+    expect(props.onMoveSelect).toHaveBeenCalledOnce()
+    expect(props.onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const { props } = renderPopover()
+    fireEvent.click(screen.getByRole('button', { name: /close move browser/i }))
+    expect(props.onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose on Escape key', () => {
+    const { props } = renderPopover()
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(props.onClose).toHaveBeenCalledOnce()
+  })
+
+  it('disables move buttons when isBusy is true', () => {
+    renderPopover({ isBusy: true })
+    const dialog = screen.getByRole('dialog')
+    const moveBtns = Array.from(
+      dialog.querySelectorAll<HTMLButtonElement>(
+        'button:not([aria-label="Close move browser"])',
+      ),
+    )
+    expect(moveBtns.every((b) => b.disabled)).toBe(true)
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.test.tsx
@@ -84,4 +84,23 @@ describe('SkaldMovesPopover — interaction', () => {
     )
     expect(moveBtns.every((b) => b.disabled)).toBe(true)
   })
+
+  it('restores focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Trigger'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <SkaldMovesPopover isOpen isBusy={false} onClose={onClose} onMoveSelect={vi.fn()} />,
+    )
+    rerender(
+      <SkaldMovesPopover isOpen={false} isBusy={false} onClose={onClose} onMoveSelect={vi.fn()} />,
+    )
+
+    expect(document.activeElement).toBe(trigger)
+    document.body.removeChild(trigger)
+  })
 })

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef, type KeyboardEvent } from 'react'
+import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
+import type { Move } from '@saga-keeper/domain'
+import styles from './SkaldMovesPopover.module.css'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface SkaldMovesPopoverProps {
+  isOpen: boolean
+  isBusy: boolean
+  onClose: () => void
+  onMoveSelect: (moveId: string) => void
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const CATEGORY_ORDER = ['adventure', 'combat', 'quest', 'relationship', 'fate'] as const
+type Category = (typeof CATEGORY_ORDER)[number]
+
+const CATEGORY_LABELS: Record<string, string> = {
+  adventure: 'Adventure',
+  combat: 'Combat',
+  quest: 'Quest',
+  relationship: 'Relationship',
+  fate: 'Fate',
+}
+
+function groupByCategory(moves: Move[]): [Category, Move[]][] {
+  const map = new Map<string, Move[]>()
+  for (const move of moves) {
+    const list = map.get(move.category) ?? []
+    list.push(move)
+    map.set(move.category, list)
+  }
+  return CATEGORY_ORDER.filter((c) => map.has(c)).map((c) => [c, map.get(c)!])
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function SkaldMovesPopover({
+  isOpen,
+  isBusy,
+  onClose,
+  onMoveSelect,
+}: SkaldMovesPopoverProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const prevFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      prevFocusRef.current = document.activeElement as HTMLElement
+      closeRef.current?.focus()
+    } else {
+      prevFocusRef.current?.focus()
+      prevFocusRef.current = null
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const groups = groupByCategory(ironswornPlugin.moves.getAll())
+
+  function handleMoveClick(moveId: string) {
+    onMoveSelect(moveId)
+    onClose()
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Escape') {
+      onClose()
+      return
+    }
+    if (e.key === 'Tab') {
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      if (!focusable || focusable.length === 0) return
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+  }
+
+  return (
+    <div
+      ref={dialogRef}
+      id="skald-moves-popover"
+      className={styles.popover}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Move Browser"
+      onKeyDown={handleKeyDown}
+    >
+      <div className={styles.header}>
+        <span className={styles.title}>Moves</span>
+        <button
+          ref={closeRef}
+          type="button"
+          className={styles.closeBtn}
+          aria-label="Close move browser"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        {groups.map(([category, moves]) => (
+          <section key={category} aria-label={CATEGORY_LABELS[category]}>
+            <h3 className={styles.categoryHeading}>{CATEGORY_LABELS[category]}</h3>
+            <ul className={styles.moveList}>
+              {moves.map((move) => (
+                <li key={move.id}>
+                  <button
+                    type="button"
+                    className={styles.moveBtn}
+                    data-category={category}
+                    disabled={isBusy}
+                    onClick={() => handleMoveClick(move.id)}
+                  >
+                    <span className={styles.moveName}>{move.name}</span>
+                    <span className={styles.moveStats}>{move.stats.join(' / ')}</span>
+                    <span className={styles.moveTrigger}>{move.trigger}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type KeyboardEvent } from 'react'
+import { createPortal } from 'react-dom'
 import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
 import type { Move } from '@saga-keeper/domain'
 import styles from './SkaldMovesPopover.module.css'
@@ -92,7 +93,7 @@ export function SkaldMovesPopover({
     }
   }
 
-  return (
+  return createPortal(
     <div
       ref={dialogRef}
       id="skald-moves-popover"
@@ -139,6 +140,7 @@ export function SkaldMovesPopover({
           </section>
         ))}
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
@@ -58,6 +58,14 @@ export function SkaldMovesPopover({
     }
   }, [isOpen])
 
+  // Inert the app root so screen readers cannot escape the dialog
+  useEffect(() => {
+    if (!isOpen) return
+    const root = document.getElementById('root')
+    root?.setAttribute('inert', '')
+    return () => root?.removeAttribute('inert')
+  }, [isOpen])
+
   if (!isOpen) return null
 
   const groups = groupByCategory(ironswornPlugin.moves.getAll())

--- a/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldMovesPopover/SkaldMovesPopover.tsx
@@ -79,6 +79,7 @@ export function SkaldMovesPopover({
       if (!focusable || focusable.length === 0) return
       const first = focusable[0]!
       const last = focusable[focusable.length - 1]!
+      if (first === last) return
       if (e.shiftKey) {
         if (document.activeElement === first) {
           e.preventDefault()

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
@@ -63,6 +63,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+  padding: 12px 16px;
 }
 
 /* ── BROWSE LAYOUT ── */
@@ -74,7 +75,6 @@
 
 /* ── RECENT TAB ── */
 .recentEmpty {
-  padding: 20px;
   text-align: center;
   font-size: 10px;
   color: var(--color-stone, #5f5447);
@@ -85,7 +85,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px;
 }
 
 .clearBtn {

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
@@ -1,0 +1,148 @@
+.popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 0;
+  width: 340px;
+  background: var(--color-ash, #13100d);
+  border: 1px solid rgba(212, 148, 26, 0.25);
+  border-radius: 4px;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.6);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  max-height: 480px;
+}
+
+/* ── TAB STRIP ── */
+.tabList {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.15);
+  flex-shrink: 0;
+}
+
+.tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-bone, #7a6a52);
+  padding: 8px 4px;
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.tab:hover,
+.tab[aria-selected='true'] {
+  color: var(--color-gold, #d4941a);
+  border-bottom-color: var(--color-gold, #d4941a);
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  color: var(--color-bone, #7a6a52);
+  padding: 8px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+
+.closeBtn:hover {
+  color: var(--color-parchment, #c4a96e);
+}
+
+/* ── TAB PANEL ── */
+.tabPanel {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+/* ── BROWSE LAYOUT ── */
+.browseLayout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* ── RECENT TAB ── */
+.recentEmpty {
+  padding: 20px;
+  text-align: center;
+  font-size: 10px;
+  color: var(--color-stone, #5f5447);
+  font-style: italic;
+}
+
+.recent {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+}
+
+.clearBtn {
+  align-self: flex-end;
+  background: transparent;
+  border: 1px solid rgba(212, 148, 26, 0.2);
+  border-radius: 2px;
+  color: var(--color-bone, #7a6a52);
+  padding: 3px 8px;
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.recentList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.recentItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  background: rgba(19, 16, 13, 0.5);
+  border: 1px solid rgba(42, 36, 28, 0.8);
+  border-radius: 2px;
+  font-size: 9px;
+}
+
+.yes {
+  color: var(--color-gold-bright, #f0b429);
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.no {
+  color: #c0392b;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.rollResult {
+  color: var(--color-parchment, #c4a96e);
+  font-style: italic;
+}
+
+.recentMeta {
+  font-size: 8px;
+  color: var(--color-stone, #5f5447);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
@@ -1,8 +1,8 @@
 .popover {
-  position: absolute;
-  bottom: 100%;
+  position: fixed;
+  bottom: 80px;
   right: 20px;
-  margin-bottom: 6px;
+  margin-bottom: 0;
   width: 340px;
   background: var(--color-ash, #13100d);
   border: 1px solid rgba(212, 148, 26, 0.25);

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.module.css
@@ -1,7 +1,8 @@
 .popover {
   position: absolute;
-  bottom: calc(100% + 8px);
-  right: 0;
+  bottom: 100%;
+  right: 20px;
+  margin-bottom: 6px;
   width: 340px;
   background: var(--color-ash, #13100d);
   border: 1px solid rgba(212, 148, 26, 0.25);

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SkaldOraclePopover } from './SkaldOraclePopover'
 import { useGameStore } from '@/store'
@@ -26,9 +26,18 @@ function setupStore(overrides: Record<string, unknown> = {}) {
   })
 }
 
+let rootEl: HTMLDivElement
+
 beforeEach(() => {
   vi.clearAllMocks()
   setupStore()
+  rootEl = document.createElement('div')
+  rootEl.id = 'root'
+  document.body.appendChild(rootEl)
+})
+
+afterEach(() => {
+  document.body.removeChild(rootEl)
 })
 
 describe('SkaldOraclePopover — visibility', () => {
@@ -191,5 +200,54 @@ describe('SkaldOraclePopover — focus management', () => {
 
     expect(document.activeElement).toBe(trigger)
     document.body.removeChild(trigger)
+  })
+})
+
+describe('SkaldOraclePopover — inert background', () => {
+  it('sets inert on #root when open', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(document.getElementById('root')?.hasAttribute('inert')).toBe(true)
+  })
+
+  it('removes inert from #root when closed', () => {
+    const { rerender } = render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    rerender(<SkaldOraclePopover isOpen={false} onClose={vi.fn()} />)
+    expect(document.getElementById('root')?.hasAttribute('inert')).toBe(false)
+  })
+})
+
+describe('SkaldOraclePopover — tablist arrow-key navigation', () => {
+  it('active tab has tabIndex=0, inactive tabs have tabIndex=-1', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const askFatesTab = screen.getByRole('tab', { name: /ask fates/i }) as HTMLButtonElement
+    const browseTab = screen.getByRole('tab', { name: /browse tables/i }) as HTMLButtonElement
+    const recentTab = screen.getByRole('tab', { name: /recent/i }) as HTMLButtonElement
+    expect(askFatesTab.tabIndex).toBe(0)
+    expect(browseTab.tabIndex).toBe(-1)
+    expect(recentTab.tabIndex).toBe(-1)
+  })
+
+  it('ArrowRight moves to the next tab', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const tablist = screen.getByRole('tablist')
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(screen.getByRole('tab', { name: /browse tables/i }).getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByRole('tab', { name: /ask fates/i }).getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('ArrowLeft from the first tab wraps to the last tab', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const tablist = screen.getByRole('tablist')
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    expect(screen.getByRole('tab', { name: /recent/i }).getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('ArrowRight from the last tab wraps to the first tab', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const tablist = screen.getByRole('tablist')
+    // Move to Recent (last tab)
+    fireEvent.click(screen.getByRole('tab', { name: /recent/i }))
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(screen.getByRole('tab', { name: /ask fates/i }).getAttribute('aria-selected')).toBe('true')
   })
 })

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SkaldOraclePopover } from './SkaldOraclePopover'
+import { useGameStore } from '@/store'
+
+vi.mock('@/store', () => ({
+  useGameStore: vi.fn(),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setupStore(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useGameStore).mockImplementation((selector: (s: any) => unknown) => {
+    const state = {
+      draft: { tableId: null, odds: null },
+      lastFates: null,
+      lastResult: null,
+      history: [],
+      fatesHistory: [],
+      setDraft: vi.fn(),
+      recordFates: vi.fn(),
+      recordOracleRoll: vi.fn(),
+      clearHistory: vi.fn(),
+      ...overrides,
+    }
+    return selector(state)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setupStore()
+})
+
+describe('SkaldOraclePopover — visibility', () => {
+  it('does not render when isOpen is false', () => {
+    render(<SkaldOraclePopover isOpen={false} onClose={vi.fn()} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders when isOpen is true', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  it('has aria-modal="true"', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true')
+  })
+
+  it('has aria-label "Oracle"', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog', { name: /oracle/i })).toBeTruthy()
+  })
+
+  it('has id="skald-oracle-popover"', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog').id).toBe('skald-oracle-popover')
+  })
+
+  it('pressing Escape calls onClose', () => {
+    const onClose = vi.fn()
+    render(<SkaldOraclePopover isOpen onClose={onClose} />)
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SkaldOraclePopover — tab navigation', () => {
+  it('renders three tab buttons: Ask Fates, Browse Tables, Recent', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('tab', { name: /ask fates/i })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: /browse tables/i })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: /recent/i })).toBeTruthy()
+  })
+
+  it('Ask Fates tab is selected by default', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const tab = screen.getByRole('tab', { name: /ask fates/i })
+    expect(tab.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('inactive tabs have aria-selected="false"', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('tab', { name: /browse tables/i }).getAttribute('aria-selected')).toBe('false')
+    expect(screen.getByRole('tab', { name: /recent/i }).getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('clicking Browse Tables activates that tab', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('tab', { name: /browse tables/i }))
+    expect(screen.getByRole('tab', { name: /browse tables/i }).getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByRole('tab', { name: /ask fates/i }).getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('tab buttons have role="tab"', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs.length).toBe(3)
+  })
+
+  it('tab panels have role="tabpanel"', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('tabpanel')).toBeTruthy()
+  })
+})
+
+describe('SkaldOraclePopover — Ask Fates tab', () => {
+  it('renders 6 odds pills', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    // The AskFatesPanel renders 6 odds buttons
+    const oddsBtns = screen.getAllByRole('button', { name: /small chance|unlikely|fifty-fifty|likely|almost certain|certain/i })
+    expect(oddsBtns.length).toBe(6)
+  })
+
+  it('Consult button is disabled when no odds selected', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    const consultBtn = screen.getByRole('button', { name: /consult the oracle/i }) as HTMLButtonElement
+    expect(consultBtn.disabled).toBe(true)
+  })
+
+  it('shows last fates result when lastFates is set', () => {
+    setupStore({
+      lastFates: {
+        odds: 'likely',
+        roll: 45,
+        result: true,
+        extreme: false,
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+    })
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    // "Yes" appears as the result answer (case-sensitive, standalone)
+    expect(screen.getByText('Yes')).toBeTruthy()
+  })
+})
+
+describe('SkaldOraclePopover — Recent tab', () => {
+  it('shows empty state when history is empty', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('tab', { name: /recent/i }))
+    expect(screen.getByText(/no revelations yet/i)).toBeTruthy()
+  })
+
+  it('shows oracle roll entries in recent tab', () => {
+    setupStore({
+      history: [
+        { tableId: 'action', roll: 42, raw: 'Inspect', timestamp: '2026-01-01T00:00:00.000Z' },
+      ],
+    })
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('tab', { name: /recent/i }))
+    expect(screen.getByText('Inspect')).toBeTruthy()
+  })
+
+  it('shows fates entries in recent tab', () => {
+    setupStore({
+      fatesHistory: [
+        { odds: 'unlikely', roll: 80, result: false, extreme: false, timestamp: '2026-01-01T00:00:00.000Z' },
+      ],
+    })
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('tab', { name: /recent/i }))
+    // "No" appears as the result (standalone text)
+    expect(screen.getByText('No')).toBeTruthy()
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
@@ -102,6 +102,17 @@ describe('SkaldOraclePopover — tab navigation', () => {
     render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
     expect(screen.getByRole('tabpanel')).toBeTruthy()
   })
+
+  it('active tabpanel aria-labelledby matches active tab id', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    expect(screen.getByRole('tabpanel').getAttribute('aria-labelledby')).toBe('oracle-tab-ask-fates')
+  })
+
+  it('tabpanel aria-labelledby updates when switching to Browse Tables', () => {
+    render(<SkaldOraclePopover isOpen onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('tab', { name: /browse tables/i }))
+    expect(screen.getByRole('tabpanel').getAttribute('aria-labelledby')).toBe('oracle-tab-browse-tables')
+  })
 })
 
 describe('SkaldOraclePopover — Ask Fates tab', () => {

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.test.tsx
@@ -175,3 +175,21 @@ describe('SkaldOraclePopover — Recent tab', () => {
     expect(screen.getByText('No')).toBeTruthy()
   })
 })
+
+describe('SkaldOraclePopover — focus management', () => {
+  it('restores focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Trigger'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const onClose = vi.fn()
+    const { rerender } = render(<SkaldOraclePopover isOpen onClose={onClose} />)
+    // Close the popover
+    rerender(<SkaldOraclePopover isOpen={false} onClose={onClose} />)
+
+    expect(document.activeElement).toBe(trigger)
+    document.body.removeChild(trigger)
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
@@ -24,6 +24,7 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
   const [activeTab, setActiveTab] = useState<Tab>('ask-fates')
   const dialogRef = useRef<HTMLDivElement>(null)
   const firstTabRef = useRef<HTMLButtonElement>(null)
+  const prevFocusRef = useRef<HTMLElement | null>(null)
 
   // oracle store
   const tables = ironswornPlugin.oracle.getTables()
@@ -37,10 +38,14 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
   const recordOracleRoll = useGameStore((s) => s.recordOracleRoll)
   const clearHistory = useGameStore((s) => s.clearHistory)
 
-  // Focus first tab when popover opens
+  // Save previous focus, move focus in, and return it on close
   useEffect(() => {
     if (isOpen) {
+      prevFocusRef.current = document.activeElement as HTMLElement
       firstTabRef.current?.focus()
+    } else {
+      prevFocusRef.current?.focus()
+      prevFocusRef.current = null
     }
   }, [isOpen])
 
@@ -61,6 +66,26 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
     if (e.key === 'Escape') {
       onClose()
+      return
+    }
+    if (e.key === 'Tab') {
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      if (!focusable || focusable.length === 0) return
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
     }
   }
 
@@ -168,12 +193,12 @@ function RecentTab({ history, fatesHistory, tables, onClear }: RecentTabProps) {
 
   return (
     <div className={styles.recent}>
-      <button type="button" className={styles.clearBtn} onClick={onClear}>
+      <button type="button" className={styles.clearBtn} aria-label="Clear Oracle History" onClick={onClear}>
         Clear
       </button>
       <ul className={styles.recentList}>
-        {combined.map((entry, idx) => (
-          <li key={idx} className={styles.recentItem}>
+        {combined.map((entry) => (
+          <li key={`${entry.kind}-${entry.data.timestamp}`} className={styles.recentItem}>
             {entry.kind === 'fates' ? (
               <span className={entry.data.result ? styles.yes : styles.no}>
                 {entry.data.result ? 'Yes' : 'No'}

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
+import { useGameStore } from '@/store'
+import { AskFatesPanel } from '../../../oracle/components/AskFatesPanel/AskFatesPanel'
+import { OracleTableBrowser } from '../../../oracle/components/OracleTableBrowser/OracleTableBrowser'
+import { OracleTableRollPanel } from '../../../oracle/components/OracleTableRollPanel/OracleTableRollPanel'
+import type { OracleRoll, FatesResult } from '@saga-keeper/domain'
+import styles from './SkaldOraclePopover.module.css'
+
+type Tab = 'ask-fates' | 'browse-tables' | 'recent'
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'ask-fates', label: 'Ask Fates' },
+  { id: 'browse-tables', label: 'Browse Tables' },
+  { id: 'recent', label: 'Recent' },
+]
+
+interface SkaldOraclePopoverProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('ask-fates')
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const firstTabRef = useRef<HTMLButtonElement>(null)
+
+  // oracle store
+  const tables = ironswornPlugin.oracle.getTables()
+  const draft = useGameStore((s) => s.draft)
+  const lastFates = useGameStore((s) => s.lastFates)
+  const lastResult = useGameStore((s) => s.lastResult)
+  const history = useGameStore((s) => s.history)
+  const fatesHistory = useGameStore((s) => s.fatesHistory)
+  const setDraft = useGameStore((s) => s.setDraft)
+  const recordFates = useGameStore((s) => s.recordFates)
+  const recordOracleRoll = useGameStore((s) => s.recordOracleRoll)
+  const clearHistory = useGameStore((s) => s.clearHistory)
+
+  // Focus first tab when popover opens
+  useEffect(() => {
+    if (isOpen) {
+      firstTabRef.current?.focus()
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const selectedTable = tables.find((t) => t.id === draft.tableId) ?? null
+
+  function handleFatesRoll() {
+    if (!draft.odds) return
+    recordFates(ironswornPlugin.oracle.rollAskFates(draft.odds))
+  }
+
+  function handleTableRoll() {
+    if (!draft.tableId) return
+    recordOracleRoll(ironswornPlugin.oracle.roll(draft.tableId))
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Escape') {
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      ref={dialogRef}
+      id="skald-oracle-popover"
+      className={styles.popover}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Oracle"
+      onKeyDown={handleKeyDown}
+    >
+      {/* Tab strip */}
+      <div className={styles.tabList} role="tablist" aria-label="Oracle sections">
+        {TABS.map((tab, idx) => (
+          <button
+            key={tab.id}
+            ref={idx === 0 ? firstTabRef : undefined}
+            type="button"
+            role="tab"
+            id={`oracle-tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`oracle-panel-${tab.id}`}
+            className={styles.tab}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <button type="button" className={styles.closeBtn} aria-label="Close oracle" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+
+      {/* Tab panel */}
+      <div
+        className={styles.tabPanel}
+        role="tabpanel"
+        id={`oracle-panel-${activeTab}`}
+        aria-labelledby={`oracle-tab-${activeTab}`}
+      >
+        {activeTab === 'ask-fates' && (
+          <AskFatesPanel
+            selectedOdds={draft.odds}
+            lastFates={lastFates}
+            onOddsSelect={(odds) => setDraft({ odds })}
+            onRoll={handleFatesRoll}
+          />
+        )}
+
+        {activeTab === 'browse-tables' && (
+          <div className={styles.browseLayout}>
+            <OracleTableBrowser
+              tables={tables}
+              selectedTableId={draft.tableId}
+              onSelect={(tableId) => setDraft({ tableId, odds: null })}
+            />
+            {selectedTable && (
+              <OracleTableRollPanel
+                table={selectedTable}
+                lastResult={lastResult?.tableId === selectedTable.id ? lastResult : null}
+                onRoll={handleTableRoll}
+              />
+            )}
+          </div>
+        )}
+
+        {activeTab === 'recent' && (
+          <RecentTab
+            history={history}
+            fatesHistory={fatesHistory}
+            tables={tables.reduce<Record<string, string>>((acc, t) => {
+              acc[t.id] = t.name
+              return acc
+            }, {})}
+            onClear={clearHistory}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface RecentTabProps {
+  history: OracleRoll[]
+  fatesHistory: FatesResult[]
+  tables: Record<string, string>
+  onClear: () => void
+}
+
+function RecentTab({ history, fatesHistory, tables, onClear }: RecentTabProps) {
+  const combined = [
+    ...history.map((r) => ({ kind: 'roll' as const, data: r })),
+    ...fatesHistory.map((f) => ({ kind: 'fates' as const, data: f })),
+  ].sort((a, b) => b.data.timestamp.localeCompare(a.data.timestamp))
+
+  if (combined.length === 0) {
+    return (
+      <div className={styles.recentEmpty}>
+        <p>No revelations yet</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.recent}>
+      <button type="button" className={styles.clearBtn} onClick={onClear}>
+        Clear
+      </button>
+      <ul className={styles.recentList}>
+        {combined.map((entry, idx) => (
+          <li key={idx} className={styles.recentItem}>
+            {entry.kind === 'fates' ? (
+              <span className={entry.data.result ? styles.yes : styles.no}>
+                {entry.data.result ? 'Yes' : 'No'}
+                {entry.data.extreme && ' (Extreme)'}
+              </span>
+            ) : (
+              <span className={styles.rollResult}>{entry.data.raw}</span>
+            )}
+            <span className={styles.recentMeta}>
+              {entry.kind === 'fates'
+                ? entry.data.odds
+                : tables[entry.data.tableId] ?? entry.data.tableId}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
@@ -24,7 +24,7 @@ interface SkaldOraclePopoverProps {
 export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps) {
   const [activeTab, setActiveTab] = useState<Tab>('ask-fates')
   const dialogRef = useRef<HTMLDivElement>(null)
-  const firstTabRef = useRef<HTMLButtonElement>(null)
+  const tabRefs = useRef<Partial<Record<Tab, HTMLButtonElement>>>({})
   const prevFocusRef = useRef<HTMLElement | null>(null)
 
   // oracle store
@@ -39,15 +39,28 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
   const recordOracleRoll = useGameStore((s) => s.recordOracleRoll)
   const clearHistory = useGameStore((s) => s.clearHistory)
 
-  // Save previous focus, move focus in, and return it on close
+  // Save previous focus on open; restore it on close
   useEffect(() => {
     if (isOpen) {
       prevFocusRef.current = document.activeElement as HTMLElement
-      firstTabRef.current?.focus()
     } else {
       prevFocusRef.current?.focus()
       prevFocusRef.current = null
     }
+  }, [isOpen])
+
+  // Focus active tab when popover opens or active tab changes (roving tabIndex)
+  useEffect(() => {
+    if (!isOpen) return
+    tabRefs.current[activeTab]?.focus()
+  }, [activeTab, isOpen])
+
+  // Inert the app root so screen readers cannot escape the dialog
+  useEffect(() => {
+    if (!isOpen) return
+    const root = document.getElementById('root')
+    root?.setAttribute('inert', '')
+    return () => root?.removeAttribute('inert')
   }, [isOpen])
 
   if (!isOpen) return null
@@ -62,6 +75,18 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
   function handleTableRoll() {
     if (!draft.tableId) return
     recordOracleRoll(ironswornPlugin.oracle.roll(draft.tableId))
+  }
+
+  function handleTablistKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    const tabs: Tab[] = ['ask-fates', 'browse-tables', 'recent']
+    const idx = tabs.indexOf(activeTab)
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      setActiveTab(tabs[(idx + 1) % tabs.length]!)
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      setActiveTab(tabs[(idx - 1 + tabs.length) % tabs.length]!)
+    }
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
@@ -102,16 +127,17 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
       onKeyDown={handleKeyDown}
     >
       {/* Tab strip */}
-      <div className={styles.tabList} role="tablist" aria-label="Oracle sections">
-        {TABS.map((tab, idx) => (
+      <div className={styles.tabList} role="tablist" aria-label="Oracle sections" onKeyDown={handleTablistKeyDown}>
+        {TABS.map((tab) => (
           <button
             key={tab.id}
-            ref={idx === 0 ? firstTabRef : undefined}
+            ref={(el) => { if (el) tabRefs.current[tab.id] = el }}
             type="button"
             role="tab"
             id={`oracle-tab-${tab.id}`}
             aria-selected={activeTab === tab.id}
             aria-controls={`oracle-panel-${tab.id}`}
+            tabIndex={activeTab === tab.id ? 0 : -1}
             className={styles.tab}
             onClick={() => setActiveTab(tab.id)}
           >

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
@@ -76,6 +76,7 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
       if (!focusable || focusable.length === 0) return
       const first = focusable[0]!
       const last = focusable[focusable.length - 1]!
+      if (first === last) return
       if (e.shiftKey) {
         if (document.activeElement === first) {
           e.preventDefault()

--- a/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
+++ b/apps/web/src/screens/skald/components/SkaldOraclePopover/SkaldOraclePopover.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, type KeyboardEvent } from 'react'
+import { createPortal } from 'react-dom'
 import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
 import { AskFatesPanel } from '../../../oracle/components/AskFatesPanel/AskFatesPanel'
@@ -89,7 +90,7 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
     }
   }
 
-  return (
+  return createPortal(
     <div
       ref={dialogRef}
       id="skald-oracle-popover"
@@ -166,7 +167,8 @@ export function SkaldOraclePopover({ isOpen, onClose }: SkaldOraclePopoverProps)
           />
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.module.css
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.module.css
@@ -1,0 +1,165 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sectionTitle {
+  font-size: 8px;
+  letter-spacing: 4px;
+  color: var(--color-iron, #3d3428);
+  text-transform: uppercase;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(30, 23, 16, 1);
+  margin: 0;
+}
+
+.emptyState {
+  font-size: 9px;
+  color: var(--color-stone, #5f5447);
+  font-style: italic;
+  margin: 0;
+}
+
+/* ── SCENE BLOCK ── */
+.sceneBlock {
+  background: var(--color-ash, #13100d);
+  border: 1px solid var(--color-iron, #2a241c);
+  border-radius: 3px;
+  padding: 10px;
+}
+
+.scenePlaceholder {
+  font-size: 9px;
+  color: var(--color-stone, #5f5447);
+  font-style: italic;
+  margin: 0;
+}
+
+/* ── MOVE REFERENCE ── */
+.moveRef {
+  background: var(--color-ash, #13100d);
+  border: 1px solid rgba(30, 23, 16, 1);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.moveRefHead {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(30, 23, 16, 1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.moveRefName {
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--color-gold, #d4941a);
+}
+
+.moveRefStat {
+  font-size: 8px;
+  letter-spacing: 2px;
+  color: var(--color-stone, #5f5447);
+  text-transform: uppercase;
+}
+
+.moveRefBody {
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.moveOutcome {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.outcomeLabel {
+  font-size: 8px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.outcomeLabel.strongHit {
+  color: var(--color-gold-bright, #f0b429);
+}
+
+.outcomeLabel.weakHit {
+  color: #7ab3cc;
+}
+
+.outcomeLabel.miss {
+  color: #c0392b;
+}
+
+/* ── VOW CARD ── */
+.vowCard {
+  background: var(--color-ash, #13100d);
+  border: 1px solid rgba(139, 26, 26, 0.2);
+  border-radius: 3px;
+  padding: 10px;
+}
+
+.vowTitle {
+  font-size: 10px;
+  color: var(--color-parchment, #c4a96e);
+  font-style: italic;
+  margin: 0 0 4px;
+  line-height: 1.4;
+}
+
+.vowRank {
+  font-size: 7px;
+  letter-spacing: 2px;
+  color: #8b1a1a;
+  text-transform: uppercase;
+  margin: 0 0 6px;
+}
+
+.vowProgress {
+  display: flex;
+  gap: 3px;
+}
+
+.progressBox {
+  flex: 1;
+  height: 8px;
+  border: 1px solid rgba(139, 26, 26, 0.25);
+  border-radius: 1px;
+  background: rgba(0, 0, 0, 0.3);
+  cursor: default;
+}
+
+.progressBox.filled {
+  background: rgba(139, 26, 26, 0.55);
+  border-color: rgba(192, 57, 43, 0.45);
+}
+
+/* ── WARNING BLOCK ── */
+.warningBlock {
+  background: rgba(139, 26, 26, 0.07);
+  border: 1px solid rgba(139, 26, 26, 0.2);
+  border-radius: 3px;
+  padding: 10px;
+}
+
+.warningTitle {
+  font-size: 7px;
+  letter-spacing: 3px;
+  color: var(--color-bone, #7a6a52);
+  text-transform: uppercase;
+  margin-bottom: 5px;
+}
+
+.warningText {
+  font-size: 9px;
+  color: var(--color-bone, #7a6a52);
+  line-height: 1.6;
+  font-style: italic;
+  margin: 0;
+}

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.module.css
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.module.css
@@ -66,6 +66,15 @@
   text-transform: uppercase;
 }
 
+.moveRefDescription {
+  padding: 6px 10px;
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--color-bone, #7a6a52);
+  font-style: italic;
+  margin: 0;
+}
+
 .moveRefBody {
   padding: 8px 10px;
   display: flex;

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ironswornPlugin, type IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
+import type { CharacterState } from '@saga-keeper/domain'
+import type { TurnPhase } from '@/store/types'
+import type { PlayerAction } from '@saga-keeper/domain'
+import { SkaldRightPanel } from './SkaldRightPanel'
+
+function makeCharacter(overrides: Partial<IronswornCharacterData> = {}): CharacterState {
+  const data = { ...ironswornPlugin.character.defaults(), ...overrides }
+  return {
+    id: 'char-1',
+    campaignId: 'camp-1',
+    name: 'Björn Ashclaw',
+    rulesetId: 'ironsworn-v1',
+    data: data as Record<string, unknown>,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function renderPanel(
+  character: CharacterState | null = null,
+  pendingAction: PlayerAction | null = null,
+  phase: TurnPhase = 'idle',
+) {
+  return render(<SkaldRightPanel character={character} pendingAction={pendingAction} phase={phase} />)
+}
+
+describe('SkaldRightPanel — Active Scene', () => {
+  it('renders "Active Scene" heading', () => {
+    renderPanel()
+    expect(screen.getByText(/active scene/i)).toBeTruthy()
+  })
+
+  it('renders placeholder when no scene context', () => {
+    renderPanel()
+    expect(screen.getByText(/awaiting scene/i)).toBeTruthy()
+  })
+})
+
+describe('SkaldRightPanel — Move Reference', () => {
+  it('renders "Move Reference" heading', () => {
+    renderPanel()
+    expect(screen.getByText(/move reference/i)).toBeTruthy()
+  })
+
+  it('renders move name when pendingAction has a moveId', () => {
+    const action: PlayerAction = { type: 'move', moveId: 'compel', statKey: 'heart' }
+    renderPanel(null, action)
+    expect(screen.getByText(/compel/i)).toBeTruthy()
+  })
+
+  it('renders Strong Hit label when move reference is shown', () => {
+    const action: PlayerAction = { type: 'move', moveId: 'compel', statKey: 'heart' }
+    renderPanel(null, action)
+    expect(screen.getByText(/strong hit/i)).toBeTruthy()
+  })
+
+  it('renders Weak Hit label when move reference is shown', () => {
+    const action: PlayerAction = { type: 'move', moveId: 'compel', statKey: 'heart' }
+    renderPanel(null, action)
+    expect(screen.getByText(/weak hit/i)).toBeTruthy()
+  })
+
+  it('renders Miss label when move reference is shown', () => {
+    const action: PlayerAction = { type: 'move', moveId: 'compel', statKey: 'heart' }
+    renderPanel(null, action)
+    expect(screen.getByText(/miss/i)).toBeTruthy()
+  })
+
+  it('renders empty state when no pending action', () => {
+    renderPanel()
+    expect(screen.getByText(/no active move/i)).toBeTruthy()
+  })
+})
+
+describe('SkaldRightPanel — Vow Tracker', () => {
+  it('renders "Tracked Vows" heading', () => {
+    renderPanel()
+    expect(screen.getByText(/tracked vows/i)).toBeTruthy()
+  })
+
+  it('renders "No vows" placeholder when character has no vows', () => {
+    renderPanel(makeCharacter({ vows: [] }))
+    expect(screen.getByText(/no vows sworn/i)).toBeTruthy()
+  })
+
+  it('renders vow title', () => {
+    const char = makeCharacter({
+      vows: [{ id: 'v1', title: 'Find the runestone', rank: 'dangerous', progress: 4, fulfilled: false }],
+    })
+    renderPanel(char)
+    expect(screen.getByText('Find the runestone')).toBeTruthy()
+  })
+
+  it('renders vow rank label', () => {
+    const char = makeCharacter({
+      vows: [{ id: 'v1', title: 'Find the runestone', rank: 'dangerous', progress: 4, fulfilled: false }],
+    })
+    renderPanel(char)
+    expect(screen.getByText(/dangerous/i)).toBeTruthy()
+  })
+
+  it('renders 10 progress boxes per vow', () => {
+    const char = makeCharacter({
+      vows: [{ id: 'v1', title: 'Test Vow', rank: 'troublesome', progress: 3, fulfilled: false }],
+    })
+    renderPanel(char)
+    const boxes = screen.getAllByRole('checkbox')
+    expect(boxes.length).toBe(10)
+  })
+
+  it('filled boxes up to progress value have aria-checked="true"', () => {
+    const char = makeCharacter({
+      vows: [{ id: 'v1', title: 'Test Vow', rank: 'troublesome', progress: 4, fulfilled: false }],
+    })
+    renderPanel(char)
+    const boxes = screen.getAllByRole('checkbox')
+    const checkedBoxes = boxes.filter((b) => b.getAttribute('aria-checked') === 'true')
+    expect(checkedBoxes.length).toBe(4)
+  })
+
+  it('unfilled boxes have aria-checked="false"', () => {
+    const char = makeCharacter({
+      vows: [{ id: 'v1', title: 'Test Vow', rank: 'troublesome', progress: 3, fulfilled: false }],
+    })
+    renderPanel(char)
+    const boxes = screen.getAllByRole('checkbox')
+    const unchecked = boxes.filter((b) => b.getAttribute('aria-checked') === 'false')
+    expect(unchecked.length).toBe(7)
+  })
+})
+
+describe('SkaldRightPanel — Warning', () => {
+  it('does not render warning block when phase is not "error"', () => {
+    renderPanel(null, null, 'idle')
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('renders warning block when phase is "error"', () => {
+    renderPanel(null, null, 'error')
+    expect(screen.getByRole('alert')).toBeTruthy()
+  })
+})

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.test.tsx
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.test.tsx
@@ -102,33 +102,25 @@ describe('SkaldRightPanel — Vow Tracker', () => {
     expect(screen.getByText(/dangerous/i)).toBeTruthy()
   })
 
-  it('renders 10 progress boxes per vow', () => {
+  it('vow progress uses role="progressbar" with aria-valuenow', () => {
     const char = makeCharacter({
       vows: [{ id: 'v1', title: 'Test Vow', rank: 'troublesome', progress: 3, fulfilled: false }],
     })
     renderPanel(char)
-    const boxes = screen.getAllByRole('checkbox')
-    expect(boxes.length).toBe(10)
+    const bar = screen.getByRole('progressbar', { name: /test vow progress/i })
+    expect(bar.getAttribute('aria-valuenow')).toBe('3')
+    expect(bar.getAttribute('aria-valuemin')).toBe('0')
+    expect(bar.getAttribute('aria-valuemax')).toBe('10')
   })
 
-  it('filled boxes up to progress value have aria-checked="true"', () => {
+  it('progress boxes are presentational (aria-hidden)', () => {
     const char = makeCharacter({
       vows: [{ id: 'v1', title: 'Test Vow', rank: 'troublesome', progress: 4, fulfilled: false }],
     })
     renderPanel(char)
-    const boxes = screen.getAllByRole('checkbox')
-    const checkedBoxes = boxes.filter((b) => b.getAttribute('aria-checked') === 'true')
-    expect(checkedBoxes.length).toBe(4)
-  })
-
-  it('unfilled boxes have aria-checked="false"', () => {
-    const char = makeCharacter({
-      vows: [{ id: 'v1', title: 'Test Vow', rank: 'troublesome', progress: 3, fulfilled: false }],
-    })
-    renderPanel(char)
-    const boxes = screen.getAllByRole('checkbox')
-    const unchecked = boxes.filter((b) => b.getAttribute('aria-checked') === 'false')
-    expect(unchecked.length).toBe(7)
+    const bar = screen.getByRole('progressbar', { name: /test vow progress/i })
+    const boxes = bar.querySelectorAll('[aria-hidden="true"]')
+    expect(boxes.length).toBe(10)
   })
 })
 

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.tsx
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.tsx
@@ -38,6 +38,7 @@ export function SkaldRightPanel({ character, pendingAction, phase }: SkaldRightP
               <span className={styles.moveRefName}>{activeMove.name}</span>
               <span className={styles.moveRefStat}>{activeMove.stats.join(' / ')}</span>
             </div>
+            <p className={styles.moveRefDescription}>{activeMove.description}</p>
             <div className={styles.moveRefBody}>
               <div className={styles.moveOutcome}>
                 <div className={`${styles.outcomeLabel} ${styles.strongHit}`}>Strong Hit</div>

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.tsx
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.tsx
@@ -14,9 +14,10 @@ export function SkaldRightPanel({ character, pendingAction, phase }: SkaldRightP
   const data = character ? (character.data as unknown as IronswornCharacterData) : null
   const vows: IronswornVow[] = data?.vows ?? []
 
-  const activeMove = pendingAction?.moveId
-    ? ironswornPlugin.moves.getAll().find((m) => m.id === pendingAction.moveId) ?? null
-    : null
+  const activeMove =
+    pendingAction?.type === 'move' && pendingAction.moveId
+      ? ironswornPlugin.moves.getAll().find((m) => m.id === pendingAction.moveId) ?? null
+      : null
 
   return (
     <>
@@ -86,16 +87,17 @@ function VowCard({ vow }: VowCardProps) {
       <p className={styles.vowRank}>{vow.rank}</p>
       <div
         className={styles.vowProgress}
-        role="group"
+        role="progressbar"
         aria-label={`${vow.title} progress`}
+        aria-valuenow={vow.progress}
+        aria-valuemin={0}
+        aria-valuemax={10}
       >
         {Array.from({ length: 10 }, (_, i) => (
           <span
             key={i}
             className={`${styles.progressBox} ${i < vow.progress ? styles.filled : ''}`}
-            role="checkbox"
-            aria-checked={i < vow.progress}
-            aria-label={`Progress box ${i + 1}`}
+            aria-hidden="true"
           />
         ))}
       </div>

--- a/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.tsx
+++ b/apps/web/src/screens/skald/components/SkaldRightPanel/SkaldRightPanel.tsx
@@ -1,0 +1,104 @@
+import type { CharacterState, PlayerAction } from '@saga-keeper/domain'
+import type { IronswornCharacterData, IronswornVow } from '@saga-keeper/ruleset-ironsworn'
+import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
+import type { TurnPhase } from '@/store/types'
+import styles from './SkaldRightPanel.module.css'
+
+interface SkaldRightPanelProps {
+  character: CharacterState | null
+  pendingAction: PlayerAction | null
+  phase: TurnPhase
+}
+
+export function SkaldRightPanel({ character, pendingAction, phase }: SkaldRightPanelProps) {
+  const data = character ? (character.data as unknown as IronswornCharacterData) : null
+  const vows: IronswornVow[] = data?.vows ?? []
+
+  const activeMove = pendingAction?.moveId
+    ? ironswornPlugin.moves.getAll().find((m) => m.id === pendingAction.moveId) ?? null
+    : null
+
+  return (
+    <>
+      {/* Active Scene */}
+      <section className={styles.section} aria-label="Active Scene">
+        <h2 className={styles.sectionTitle}>Active Scene</h2>
+        <div className={styles.sceneBlock}>
+          <p className={styles.scenePlaceholder}>Awaiting scene context...</p>
+        </div>
+      </section>
+
+      {/* Move Reference */}
+      <section className={styles.section} aria-label="Move Reference">
+        <h2 className={styles.sectionTitle}>Move Reference</h2>
+        {activeMove ? (
+          <div className={styles.moveRef}>
+            <div className={styles.moveRefHead}>
+              <span className={styles.moveRefName}>{activeMove.name}</span>
+              <span className={styles.moveRefStat}>{activeMove.stats.join(' / ')}</span>
+            </div>
+            <div className={styles.moveRefBody}>
+              <div className={styles.moveOutcome}>
+                <div className={`${styles.outcomeLabel} ${styles.strongHit}`}>Strong Hit</div>
+              </div>
+              <div className={styles.moveOutcome}>
+                <div className={`${styles.outcomeLabel} ${styles.weakHit}`}>Weak Hit</div>
+              </div>
+              <div className={styles.moveOutcome}>
+                <div className={`${styles.outcomeLabel} ${styles.miss}`}>Miss</div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p className={styles.emptyState}>No active move</p>
+        )}
+      </section>
+
+      {/* Tracked Vows */}
+      <section className={styles.section} aria-label="Tracked Vows">
+        <h2 className={styles.sectionTitle}>Tracked Vows</h2>
+        {vows.length === 0 ? (
+          <p className={styles.emptyState}>No vows sworn</p>
+        ) : (
+          vows.map((vow) => <VowCard key={vow.id} vow={vow} />)
+        )}
+      </section>
+
+      {/* Error / Warning */}
+      {phase === 'error' && (
+        <div className={styles.warningBlock} role="alert">
+          <div className={styles.warningTitle}>Skald's Warning</div>
+          <p className={styles.warningText}>Something went wrong. Please try again.</p>
+        </div>
+      )}
+    </>
+  )
+}
+
+interface VowCardProps {
+  vow: IronswornVow
+}
+
+function VowCard({ vow }: VowCardProps) {
+  return (
+    <div className={styles.vowCard}>
+      <p className={styles.vowTitle}>{vow.title}</p>
+      <p className={styles.vowRank}>{vow.rank}</p>
+      <div
+        className={styles.vowProgress}
+        role="group"
+        aria-label={`${vow.title} progress`}
+      >
+        {Array.from({ length: 10 }, (_, i) => (
+          <span
+            key={i}
+            className={`${styles.progressBox} ${i < vow.progress ? styles.filled : ''}`}
+            role="checkbox"
+            aria-checked={i < vow.progress}
+            aria-label={`Progress box ${i + 1}`}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/screens/skald/hooks/useSkaldTurn.test.ts
+++ b/apps/web/src/screens/skald/hooks/useSkaldTurn.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSkaldTurn } from './useSkaldTurn'
+import type { TurnResult } from '@saga-keeper/domain'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/providers/NarrativeDomainProvider', () => ({
+  useNarrativeDomain: vi.fn(),
+}))
+
+vi.mock('@/store', () => ({
+  useGameStore: vi.fn(),
+}))
+
+import { useNarrativeDomain } from '@/providers/NarrativeDomainProvider'
+import { useGameStore } from '@/store'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTurnResult(overrides: Partial<TurnResult> = {}): TurnResult {
+  return {
+    turnId: 'turn-1',
+    input: { type: 'free', userText: 'I rest.' },
+    narration: '',
+    statDeltas: [],
+    extractedEntities: [],
+    timestamp: '2026-01-01T00:00:00.000Z',
+    sessionEvents: [],
+    ...overrides,
+  }
+}
+
+const mockSetPhase = vi.fn()
+const mockSetPendingAction = vi.fn()
+const mockAppendMessage = vi.fn()
+const mockApplyTurnResult = vi.fn()
+const mockProcessTurn = vi.fn()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setupStore(phase = 'idle', overrides: Record<string, unknown> = {}) {
+  vi.mocked(useGameStore).mockImplementation((selector: (s: any) => unknown) => {
+    const state = {
+      phase,
+      setPhase: mockSetPhase,
+      setPendingAction: mockSetPendingAction,
+      appendMessage: mockAppendMessage,
+      applyTurnResult: mockApplyTurnResult,
+      ...overrides,
+    }
+    return selector(state)
+  })
+}
+
+function setupDomain(processTurnImpl = mockProcessTurn) {
+  vi.mocked(useNarrativeDomain).mockReturnValue({
+    processTurn: processTurnImpl,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setupStore()
+  setupDomain()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useSkaldTurn — isSubmitting', () => {
+  it('is false when phase is idle', () => {
+    setupStore('idle')
+    const { result } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+    expect(result.current.isSubmitting).toBe(false)
+  })
+
+  it('is true when phase is resolving', () => {
+    setupStore('resolving')
+    const { result } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+    expect(result.current.isSubmitting).toBe(true)
+  })
+
+  it('is true when phase is waiting-for-ai', () => {
+    setupStore('waiting-for-ai')
+    const { result } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+    expect(result.current.isSubmitting).toBe(true)
+  })
+
+  it('is true when phase is streaming', () => {
+    setupStore('streaming')
+    const { result } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+    expect(result.current.isSubmitting).toBe(true)
+  })
+})
+
+describe('useSkaldTurn — submitAction success', () => {
+  it('sets phase to resolving before calling processTurn', async () => {
+    const result = makeTurnResult()
+    mockProcessTurn.mockResolvedValue(result)
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'I rest.' })
+    })
+
+    expect(mockSetPhase).toHaveBeenCalledWith('resolving')
+  })
+
+  it('stores pendingAction before calling processTurn', async () => {
+    mockProcessTurn.mockResolvedValue(makeTurnResult())
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'I rest.' })
+    })
+
+    expect(mockSetPendingAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'free', userText: 'I rest.' }),
+    )
+  })
+
+  it('calls processTurn with campaignId and action', async () => {
+    mockProcessTurn.mockResolvedValue(makeTurnResult())
+    const { result: hook } = renderHook(() =>
+      useSkaldTurn({ campaignId: 'camp-1', characterId: 'char-1' }),
+    )
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'Forward!' })
+    })
+
+    expect(mockProcessTurn).toHaveBeenCalledWith(
+      'camp-1',
+      expect.objectContaining({ type: 'free', userText: 'Forward!', characterId: 'char-1' }),
+    )
+  })
+
+  it('calls applyTurnResult with the returned TurnResult', async () => {
+    const turnResult = makeTurnResult({ narration: 'The fire crackles.' })
+    mockProcessTurn.mockResolvedValue(turnResult)
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'I rest.' })
+    })
+
+    expect(mockApplyTurnResult).toHaveBeenCalledWith(turnResult)
+  })
+
+  it('does not call processTurn when campaignId is empty', async () => {
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: '' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'test' })
+    })
+
+    expect(mockProcessTurn).not.toHaveBeenCalled()
+  })
+
+  it('does not call processTurn when already submitting', async () => {
+    setupStore('resolving')
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'test' })
+    })
+
+    expect(mockProcessTurn).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSkaldTurn — submitAction error', () => {
+  it('sets phase to error when processTurn rejects', async () => {
+    mockProcessTurn.mockRejectedValue(new Error('Network failure'))
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'I rest.' })
+    })
+
+    expect(mockSetPhase).toHaveBeenCalledWith('error')
+  })
+
+  it('appends a system message with the error text', async () => {
+    mockProcessTurn.mockRejectedValue(new Error('Campaign not found'))
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'I rest.' })
+    })
+
+    expect(mockAppendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'system', content: 'Campaign not found' }),
+    )
+  })
+
+  it('does not call applyTurnResult on error', async () => {
+    mockProcessTurn.mockRejectedValue(new Error('fail'))
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'free', userText: 'test' })
+    })
+
+    expect(mockApplyTurnResult).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSkaldTurn — offline tier (no narration)', () => {
+  it('calls applyTurnResult even when narration is empty (offline tier)', async () => {
+    const offlineResult = makeTurnResult({
+      narration: '',
+      move: 'face-danger',
+      outcome: {
+        result: 'strong-hit',
+        match: false,
+        consequences: [],
+        narrativeHints: ['You succeed with grace.'],
+      },
+    })
+    mockProcessTurn.mockResolvedValue(offlineResult)
+    const { result: hook } = renderHook(() => useSkaldTurn({ campaignId: 'camp-1' }))
+
+    await act(async () => {
+      await hook.current.submitAction({ type: 'move', moveId: 'face-danger', statKey: 'edge' })
+    })
+
+    // applyTurnResult is called — outcome card will be shown by the store fan-out
+    expect(mockApplyTurnResult).toHaveBeenCalledWith(offlineResult)
+  })
+})

--- a/apps/web/src/screens/skald/hooks/useSkaldTurn.ts
+++ b/apps/web/src/screens/skald/hooks/useSkaldTurn.ts
@@ -1,0 +1,66 @@
+import type { PlayerAction } from '@saga-keeper/domain'
+import { useNarrativeDomain } from '@/providers/NarrativeDomainProvider'
+import { useGameStore } from '@/store'
+
+interface UseSkaldTurnOptions {
+  campaignId: string
+  characterId?: string
+}
+
+interface UseSkaldTurnReturn {
+  submitAction: (action: PlayerAction) => Promise<void>
+  isSubmitting: boolean
+}
+
+/**
+ * L1 hook — the only boundary between the React/Zustand world and NarrativeDomain.
+ *
+ * Responsibilities:
+ *  1. Set phase to 'resolving' so the UI blocks input while the turn is in-flight.
+ *  2. Store pendingAction so SkaldRightPanel can display the active move.
+ *  3. Call narrativeDomain.processTurn() and commit the result via applyTurnResult().
+ *  4. On error: set phase to 'error' and append a system message to the feed.
+ *
+ * This hook MUST NOT import from @saga-keeper/storage or @saga-keeper/ai-gateway directly.
+ * Those are wired into NarrativeDomain by NarrativeDomainProvider.
+ */
+export function useSkaldTurn({ campaignId, characterId }: UseSkaldTurnOptions): UseSkaldTurnReturn {
+  const narrativeDomain = useNarrativeDomain()
+
+  const phase = useGameStore((s) => s.phase)
+  const setPhase = useGameStore((s) => s.setPhase)
+  const setPendingAction = useGameStore((s) => s.setPendingAction)
+  const appendMessage = useGameStore((s) => s.appendMessage)
+  const applyTurnResult = useGameStore((s) => s.applyTurnResult)
+
+  const isSubmitting =
+    phase === 'resolving' || phase === 'waiting-for-ai' || phase === 'streaming'
+
+  async function submitAction(action: PlayerAction): Promise<void> {
+    if (!campaignId) return
+    if (isSubmitting) return
+
+    const fullAction: PlayerAction = {
+      ...action,
+      ...(characterId !== undefined && { characterId }),
+    }
+
+    setPhase('resolving')
+    setPendingAction(fullAction)
+
+    try {
+      const result = await narrativeDomain.processTurn(campaignId, fullAction)
+      applyTurnResult(result)
+    } catch (err) {
+      setPhase('error')
+      appendMessage({
+        id: globalThis.crypto.randomUUID(),
+        role: 'system',
+        content: err instanceof Error ? err.message : 'An unexpected error occurred.',
+        timestamp: new Date().toISOString(),
+      })
+    }
+  }
+
+  return { submitAction, isSubmitting }
+}

--- a/apps/web/src/screens/skald/index.tsx
+++ b/apps/web/src/screens/skald/index.tsx
@@ -1,5 +1,1 @@
-// SkaldScreen — TODO: implement
-// Reference: saga-keeper-design-notes.md, saga-keeper-platform-spec.md
-export function SkaldScreen() {
-  return <div>Skald</div>
-}
+export { SkaldScreen } from './SkaldScreen'

--- a/apps/web/src/store/index.test.ts
+++ b/apps/web/src/store/index.test.ts
@@ -146,9 +146,12 @@ describe('useGameStore — applyTurnResult', () => {
     expect(useGameStore.getState().activeTurnId).toBe('turn-42')
   })
 
-  it('does not append any feed messages for a free turn with no narration', () => {
+  it('appends only the player message for a free turn with no narration (offline tier)', () => {
     useGameStore.getState().applyTurnResult(makeTurnResult({ narration: '' }))
-    expect(useGameStore.getState().messages).toHaveLength(0)
+    const msgs = useGameStore.getState().messages
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0]?.role).toBe('player')
+    expect(msgs[0]?.content).toBe('I rest by the fire.')
   })
 
   it('appends a skald message when narration is present', () => {

--- a/apps/web/src/store/index.test.ts
+++ b/apps/web/src/store/index.test.ts
@@ -146,6 +146,24 @@ describe('useGameStore — applyTurnResult', () => {
     expect(useGameStore.getState().activeTurnId).toBe('turn-42')
   })
 
+  it('appends a player bubble with the move name when input.userText is absent (move-pill action)', () => {
+    useGameStore.getState().applyTurnResult(
+      makeTurnResult({
+        input: { type: 'move', moveId: 'face-danger' },
+        move: 'face-danger',
+        outcome: {
+          result: 'strong-hit',
+          match: false,
+          consequences: [],
+          narrativeHints: [],
+        },
+      }),
+    )
+    const msgs = useGameStore.getState().messages
+    expect(msgs[0]?.role).toBe('player')
+    expect(msgs[0]?.content).toBeTruthy()
+  })
+
   it('appends only the player message for a free turn with no narration (offline tier)', () => {
     useGameStore.getState().applyTurnResult(makeTurnResult({ narration: '' }))
     const msgs = useGameStore.getState().messages

--- a/apps/web/src/store/index.test.ts
+++ b/apps/web/src/store/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useGameStore } from './index'
+import type { TurnResult } from '@saga-keeper/domain'
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -78,5 +79,160 @@ describe('useGameStore — cross-slice isolation', () => {
     })
     useGameStore.getState().clearHistory()
     expect(useGameStore.getState().turns).toHaveLength(1)
+  })
+})
+
+// ── applyTurnResult ───────────────────────────────────────────────────────────
+
+function makeTurnResult(overrides: Partial<TurnResult> = {}): TurnResult {
+  return {
+    turnId: 'turn-42',
+    input: { type: 'free', userText: 'I rest by the fire.' },
+    narration: '',
+    statDeltas: [],
+    extractedEntities: [],
+    timestamp: '2026-01-01T00:00:00.000Z',
+    sessionEvents: [
+      {
+        id: 'evt-1',
+        campaignId: 'camp-1',
+        turnId: 'turn-42',
+        type: 'player.input',
+        playerId: 'local',
+        payload: {},
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('useGameStore — applyTurnResult', () => {
+  beforeEach(() => {
+    useGameStore.setState(useGameStore.getInitialState())
+    useGameStore.getState().setPhase('resolving')
+  })
+
+  it('resets phase to idle', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult())
+    expect(useGameStore.getState().phase).toBe('idle')
+  })
+
+  it('clears streamBuffer', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult())
+    expect(useGameStore.getState().streamBuffer).toBe('')
+  })
+
+  it('appends the turn to session turns', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult())
+    expect(useGameStore.getState().turns).toHaveLength(1)
+    expect(useGameStore.getState().turns[0]?.turnId).toBe('turn-42')
+  })
+
+  it('appends all sessionEvents to session events', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult())
+    expect(useGameStore.getState().events).toHaveLength(1)
+    expect(useGameStore.getState().events[0]?.id).toBe('evt-1')
+  })
+
+  it('clears pendingAction', () => {
+    useGameStore.getState().setPendingAction({ type: 'free', userText: 'test' })
+    useGameStore.getState().applyTurnResult(makeTurnResult())
+    expect(useGameStore.getState().pendingAction).toBeNull()
+  })
+
+  it('sets activeTurnId to result.turnId', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult())
+    expect(useGameStore.getState().activeTurnId).toBe('turn-42')
+  })
+
+  it('does not append any feed messages for a free turn with no narration', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult({ narration: '' }))
+    expect(useGameStore.getState().messages).toHaveLength(0)
+  })
+
+  it('appends a skald message when narration is present', () => {
+    useGameStore.getState().applyTurnResult(makeTurnResult({ narration: 'The fire crackles.' }))
+    const skaldMsgs = useGameStore.getState().messages.filter((m) => m.role === 'skald')
+    expect(skaldMsgs).toHaveLength(1)
+    expect(skaldMsgs[0]?.content).toBe('The fire crackles.')
+  })
+
+  it('appends an outcome message when move + outcome present', () => {
+    useGameStore.getState().applyTurnResult(
+      makeTurnResult({
+        move: 'face-danger',
+        roll: {
+          actionDie: 4,
+          challengeDice: [3, 5],
+          modifier: 2,
+          total: 6,
+          result: 'weak-hit',
+          match: false,
+        },
+        outcome: {
+          result: 'weak-hit',
+          match: false,
+          consequences: [],
+          narrativeHints: [],
+        },
+      }),
+    )
+    const outcomeMsgs = useGameStore.getState().messages.filter((m) => m.role === 'outcome')
+    expect(outcomeMsgs).toHaveLength(1)
+    const data = JSON.parse(outcomeMsgs[0]!.content)
+    expect(data.moveId).toBe('face-danger')
+    expect(data.result).toBe('weak-hit')
+    expect(data.roll.total).toBe(6)
+  })
+
+  it('appends an oracle message per oracleResult', () => {
+    useGameStore.getState().applyTurnResult(
+      makeTurnResult({
+        oracleResults: [
+          { tableId: 'action', roll: 42, raw: 'Inspect', timestamp: '2026-01-01T00:00:00.000Z' },
+        ],
+      }),
+    )
+    const oracleMsgs = useGameStore.getState().messages.filter((m) => m.role === 'oracle')
+    expect(oracleMsgs).toHaveLength(1)
+    const data = JSON.parse(oracleMsgs[0]!.content)
+    expect(data.tableId).toBe('action')
+    expect(data.raw).toBe('Inspect')
+  })
+
+  it('applies stat deltas to character data and keeps isDirty false', () => {
+    useGameStore.getState().setCharacter({
+      id: 'char-1',
+      campaignId: 'camp-1',
+      name: 'Björn',
+      rulesetId: 'ironsworn-v1',
+      data: { health: 5, spirit: 3 },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+    useGameStore.getState().applyTurnResult(
+      makeTurnResult({
+        statDeltas: [{ stat: 'health', before: 5, after: 4 }],
+      }),
+    )
+    const char = useGameStore.getState().character!
+    expect((char.data as Record<string, number>).health).toBe(4)
+    expect(useGameStore.getState().isDirty).toBe(false)
+  })
+
+  it('does not modify character when statDeltas is empty', () => {
+    useGameStore.getState().setCharacter({
+      id: 'char-1',
+      campaignId: 'camp-1',
+      name: 'Björn',
+      rulesetId: 'ironsworn-v1',
+      data: { health: 5 },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+    const before = useGameStore.getState().character
+    useGameStore.getState().applyTurnResult(makeTurnResult({ statDeltas: [] }))
+    expect(useGameStore.getState().character).toBe(before)
   })
 })

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -39,6 +39,17 @@ export const useGameStore = create<GameStore>()((set, get, store) => ({
     const ts = new Date().toISOString()
     const newMessages: SkaldMessage[] = []
 
+    // Player bubble — always show what the player submitted
+    if (result.input.userText) {
+      newMessages.push({
+        id: globalThis.crypto.randomUUID(),
+        role: 'player',
+        content: result.input.userText,
+        turnId: result.turnId,
+        timestamp: ts,
+      })
+    }
+
     // Outcome card — only when a move was resolved
     if (result.outcome && result.move) {
       const moveName =

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -1,26 +1,121 @@
 /**
  * useGameStore — single Zustand store for all live game state.
  *
- * L3 services write into this store via useGameStore.getState().setX(...)
- * after each turn phase. UI components read from it via the useGameStore hook.
+ * L1 hooks call NarrativeDomain.processTurn() and commit the returned TurnResult via
+ * applyTurnResult(). L3 has no knowledge that this store exists.
  *
  * No imports from @saga-keeper/ai-gateway or @saga-keeper/storage are allowed here.
  */
 import { create } from 'zustand'
+import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
+import type { TurnResult, NarrativeTurn } from '@saga-keeper/domain'
 import { createCharacterSlice, type CharacterSlice } from './slices/characterSlice'
 import { createSkaldFeedSlice, type SkaldFeedSlice } from './slices/skaldFeedSlice'
 import { createOracleSlice, type OracleSlice } from './slices/oracleSlice'
 import { createWorldSlice, type WorldSlice } from './slices/worldSlice'
 import { createSessionSlice, type SessionSlice } from './slices/sessionSlice'
+import type { SkaldMessage, TurnPhase } from './types'
 
-export type GameStore = CharacterSlice & SkaldFeedSlice & OracleSlice & WorldSlice & SessionSlice
+export type GameStore = CharacterSlice &
+  SkaldFeedSlice &
+  OracleSlice &
+  WorldSlice &
+  SessionSlice & {
+    /**
+     * Atomically fans a completed TurnResult into the feed, session, and character slices.
+     * Called exclusively by the useSkaldTurn L1 hook after processTurn() resolves.
+     */
+    applyTurnResult: (result: TurnResult) => void
+  }
 
-export const useGameStore = create<GameStore>()((...a) => ({
-  ...createCharacterSlice(...a),
-  ...createSkaldFeedSlice(...a),
-  ...createOracleSlice(...a),
-  ...createWorldSlice(...a),
-  ...createSessionSlice(...a),
+export const useGameStore = create<GameStore>()((set, get, store) => ({
+  ...createCharacterSlice(set, get, store),
+  ...createSkaldFeedSlice(set, get, store),
+  ...createOracleSlice(set, get, store),
+  ...createWorldSlice(set, get, store),
+  ...createSessionSlice(set, get, store),
+
+  applyTurnResult: (result: TurnResult) => {
+    const ts = new Date().toISOString()
+    const newMessages: SkaldMessage[] = []
+
+    // Outcome card — only when a move was resolved
+    if (result.outcome && result.move) {
+      const moveName =
+        ironswornPlugin.moves.getAll().find((m) => m.id === result.move)?.name ?? result.move
+      newMessages.push({
+        id: globalThis.crypto.randomUUID(),
+        role: 'outcome',
+        content: JSON.stringify({
+          moveId: result.move,
+          moveName,
+          result: result.roll?.result ?? null,
+          match: result.roll?.match ?? false,
+          roll: result.roll ?? null,
+          consequences: result.outcome.consequences,
+        }),
+        turnId: result.turnId,
+        timestamp: ts,
+      })
+    }
+
+    // Oracle strip — one message per oracle result
+    for (const or of result.oracleResults ?? []) {
+      newMessages.push({
+        id: globalThis.crypto.randomUUID(),
+        role: 'oracle',
+        content: JSON.stringify({ tableId: or.tableId, roll: or.roll, raw: or.raw }),
+        turnId: result.turnId,
+        timestamp: or.timestamp,
+      })
+    }
+
+    // Skald narration — only when AI produced text (empty in offline tier)
+    if (result.narration) {
+      newMessages.push({
+        id: globalThis.crypto.randomUUID(),
+        role: 'skald',
+        content: result.narration,
+        turnId: result.turnId,
+        timestamp: ts,
+      })
+    }
+
+    // Character stat patch — service already persisted to storage, so isDirty stays false
+    const state = get()
+    let charPatch: Partial<Pick<GameStore, 'character' | 'isDirty'>> = {}
+    if (state.character && result.statDeltas.length > 0) {
+      const dataPatch: Record<string, unknown> = {}
+      for (const d of result.statDeltas) {
+        dataPatch[d.stat] = d.after
+      }
+      charPatch = {
+        character: {
+          ...state.character,
+          data: { ...(state.character.data as Record<string, unknown>), ...dataPatch },
+          updatedAt: ts,
+        },
+        isDirty: false,
+      }
+    }
+
+    // TurnResult extends NarrativeTurn — cast is safe; sessionEvents is the only extra field
+    const turn = result as NarrativeTurn
+
+    set((s) => ({
+      // Feed
+      messages: [...s.messages, ...newMessages],
+      phase: 'idle' as TurnPhase,
+      streamBuffer: '',
+      // Session
+      turns: [...s.turns, turn],
+      events: [...s.events, ...result.sessionEvents],
+      pendingAction: null,
+      activeTurnId: result.turnId,
+      // Character (only spread when there are deltas)
+      ...charPatch,
+    }))
+  },
 }))
 
 export type { TurnPhase, SkaldMessage, OracleDraft } from './types'

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -39,12 +39,17 @@ export const useGameStore = create<GameStore>()((set, get, store) => ({
     const ts = new Date().toISOString()
     const newMessages: SkaldMessage[] = []
 
-    // Player bubble — always show what the player submitted
-    if (result.input.userText) {
+    // Player bubble — show userText for free/oracle turns; fall back to move name for move-type turns
+    const playerText =
+      result.input.userText ??
+      (result.move
+        ? ironswornPlugin.moves.getAll().find((m) => m.id === result.move)?.name ?? result.move
+        : undefined)
+    if (playerText) {
       newMessages.push({
         id: globalThis.crypto.randomUUID(),
         role: 'player',
-        content: result.input.userText,
+        content: playerText,
         turnId: result.turnId,
         timestamp: ts,
       })

--- a/apps/web/src/store/slices/skaldFeedSlice.test.ts
+++ b/apps/web/src/store/slices/skaldFeedSlice.test.ts
@@ -66,7 +66,7 @@ describe('createSkaldFeedSlice — appendMessage', () => {
 // ── setPhase ──────────────────────────────────────────────────────────────────
 
 describe('createSkaldFeedSlice — setPhase', () => {
-  const phases: TurnPhase[] = ['idle', 'waiting-for-ai', 'streaming', 'move-pending', 'error']
+  const phases: TurnPhase[] = ['idle', 'resolving', 'waiting-for-ai', 'streaming', 'move-pending', 'error']
 
   it.each(phases)('accepts phase "%s"', (phase) => {
     const store = makeStore()

--- a/apps/web/src/store/types.ts
+++ b/apps/web/src/store/types.ts
@@ -1,12 +1,34 @@
 import type { Odds } from '@saga-keeper/domain'
 
-/** Current phase of a Skald turn — drives UI loading states on the Skald screen. */
-export type TurnPhase = 'idle' | 'waiting-for-ai' | 'streaming' | 'move-pending' | 'error'
+/**
+ * Current phase of a Skald turn — drives UI loading states on the Skald screen.
+ *
+ * resolving     — processTurn() is in-flight (offline: instant; AI: awaiting response).
+ *                 Input is blocked; no streaming indicator shown.
+ * waiting-for-ai — AI gateway accepted the request and is generating a response.
+ * streaming     — AI response tokens are arriving; streamBuffer is filling.
+ * move-pending  — A move has been rolled but awaits player confirmation or follow-up.
+ * error         — The last turn failed; an error message is visible in the feed.
+ */
+export type TurnPhase =
+  | 'idle'
+  | 'resolving'
+  | 'waiting-for-ai'
+  | 'streaming'
+  | 'move-pending'
+  | 'error'
 
 /** A displayable item in the Skald chat feed. */
 export interface SkaldMessage {
   id: string
-  role: 'player' | 'skald' | 'system'
+  /**
+   * player  — text the player typed or a move they triggered
+   * skald   — AI-generated narration
+   * system  — informational or error messages from the app
+   * outcome — move resolution card (content = JSON MoveOutcomeData)
+   * oracle  — oracle table result strip (content = JSON OracleStripData)
+   */
+  role: 'player' | 'skald' | 'system' | 'outcome' | 'oracle'
   content: string
   turnId?: string
   timestamp: string


### PR DESCRIPTION
## Summary

- Implements the Skald screen at `/skald` — the primary active-play interface for saga-keeper
- 3-column layout (200px sidebar | 1fr chat | 260px right panel) consistent with Oracle and Iron Sheet screens
- Enables the Skald nav button in Oracle and Iron Sheet screens

## Components

| Component | Description |
|-----------|-------------|
| `SkaldScreen` | Shell, routing, store wiring |
| `SkaldFeed` | `role="log"` chat feed — skald/player/system bubbles, streaming buffer, typing indicator, error banner |
| `SkaldInputBar` | Text input (Enter to send), quick-move pills (dynamic via `ironswornPlugin.moves.suggest()`), Oracle toggle |
| `SkaldLeftSidebar` | Character mini-card (HP/SP/MO meters), session list |
| `SkaldRightPanel` | Active Scene, Move Reference, 10-box vow progress tracks, error alert |
| `SkaldOraclePopover` | `role="dialog"` floating panel — Ask Fates / Browse Tables / Recent tabs, reuses oracle screen components |

## Notes

- **Active Scene** and **Move Reference** are intentional stubs — they populate from session events and AI pipeline (future L3 issues)
- **Quick-move pills** use `ironswornPlugin.moves.suggest()` with hardcoded `inCombat: false / onJourney: false` until session state tracks those flags — no component changes needed when that lands
- Oracle, player input, character stats, and vow tracker all work without AI

## Test plan

- [ ] 474 tests pass (`pnpm -F @saga-keeper/web test -- --run`)
- [ ] TypeScript clean (`pnpm typecheck`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Navigate to `/skald` — 3-column layout renders
- [ ] Type a message, press Enter — appears in feed as player bubble
- [ ] Click oracle button — popover opens above input bar
- [ ] Ask Fates → select odds → Consult → result appears
- [ ] Browse Tables → select table → roll → result appears
- [ ] Recent tab → shows roll history
- [ ] Press Escape — popover closes
- [ ] Navigate to Oracle/Iron Sheet — Skald nav button enabled and routes correctly

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)