### PR TITLE
refactor: extract shared AppHeader with session-gated nav tabs

### DIFF
--- a/apps/web/src/components/AppHeader/AppHeader.module.css
+++ b/apps/web/src/components/AppHeader/AppHeader.module.css
@@ -18,11 +18,24 @@
   padding: 12px 0;
 }
 
+.logoText {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 .logoTitle {
   font-family: 'Cinzel Decorative', serif;
   font-size: 14px;
   font-weight: 900;
   color: var(--color-gold-bright, #f0b429);
+  letter-spacing: 3px;
+  text-transform: uppercase;
+}
+
+.logoSub {
+  font-size: 9px;
+  color: #5f5447;
   letter-spacing: 3px;
   text-transform: uppercase;
 }

--- a/apps/web/src/components/AppHeader/AppHeader.module.css
+++ b/apps/web/src/components/AppHeader/AppHeader.module.css
@@ -1,0 +1,60 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 32px;
+  border-bottom: 1px solid rgba(212, 148, 26, 0.2);
+  background: rgba(30, 23, 16, 0.95);
+  backdrop-filter: blur(8px);
+}
+
+.logoBtn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 12px 0;
+}
+
+.logoTitle {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 14px;
+  font-weight: 900;
+  color: var(--color-gold-bright, #f0b429);
+  letter-spacing: 3px;
+  text-transform: uppercase;
+}
+
+.nav {
+  display: flex;
+  gap: 2px;
+}
+
+.navBtn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-bone, #7a6a52);
+  padding: 6px 14px;
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s;
+  border-radius: 2px;
+  height: 47px;
+}
+
+.navBtn:hover:not(:disabled),
+.navBtn[aria-current='page'] {
+  border-color: rgba(212, 148, 26, 0.4);
+  color: var(--color-gold, #d4941a);
+  background: rgba(212, 148, 26, 0.08);
+}
+
+.navBtn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}

--- a/apps/web/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/web/src/components/AppHeader/AppHeader.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AppHeader } from './AppHeader'
+import { useGameStore } from '@/store'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/oracle' }),
+}))
+
+beforeEach(() => {
+  useGameStore.setState(useGameStore.getInitialState())
+  mockNavigate.mockClear()
+})
+
+describe('AppHeader — structure', () => {
+  it('renders a banner landmark', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('banner')).toBeTruthy()
+  })
+
+  it('renders Application nav', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('navigation', { name: /application/i })).toBeTruthy()
+  })
+
+  it('renders "Saga Keeper" logo text', () => {
+    render(<AppHeader />)
+    expect(screen.getByText(/saga keeper/i)).toBeTruthy()
+  })
+
+  it('logo button has aria-label "Go to Great Hall"', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('button', { name: /go to great hall/i })).toBeTruthy()
+  })
+})
+
+describe('AppHeader — navigation', () => {
+  it('logo button navigates to /great-hall', () => {
+    render(<AppHeader />)
+    fireEvent.click(screen.getByRole('button', { name: /go to great hall/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
+  })
+
+  it('Oracle button navigates to /oracle', () => {
+    render(<AppHeader />)
+    fireEvent.click(screen.getByRole('button', { name: /oracle/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/oracle')
+  })
+
+  it('marks the current route as aria-current="page"', () => {
+    render(<AppHeader />)
+    const nav = screen.getByRole('navigation', { name: /application/i })
+    const activeBtn = nav.querySelector('[aria-current="page"]')
+    expect(activeBtn).toBeTruthy()
+    expect(activeBtn!.textContent).toMatch(/oracle/i)
+  })
+
+  it('Skald button is enabled and navigates to /skald', () => {
+    render(<AppHeader />)
+    const skaldBtn = screen.getByRole('button', { name: /skald/i })
+    expect((skaldBtn as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(skaldBtn)
+    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+  })
+
+  it('World Forge button is disabled', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('button', { name: /world forge/i })).toHaveProperty('disabled', true)
+  })
+})
+
+describe('AppHeader — Iron Sheet gating', () => {
+  it('Iron Sheet button is disabled when no campaign is loaded', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('button', { name: /iron sheet/i })).toHaveProperty('disabled', true)
+  })
+
+  it('Iron Sheet button is enabled when a campaign is loaded', () => {
+    useGameStore.setState({
+      campaign: {
+        id: 'c1',
+        name: 'Test Campaign',
+        rulesetId: 'ironsworn-v1',
+        status: 'active',
+        mode: 'solo',
+        characterIds: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    })
+    render(<AppHeader />)
+    const ironSheetBtn = screen.getByRole('button', { name: /iron sheet/i })
+    expect(ironSheetBtn).toHaveProperty('disabled', false)
+    fireEvent.click(ironSheetBtn)
+    expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')
+  })
+})

--- a/apps/web/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/web/src/components/AppHeader/AppHeader.test.tsx
@@ -58,12 +58,9 @@ describe('AppHeader — navigation', () => {
     expect(activeBtn!.textContent).toMatch(/oracle/i)
   })
 
-  it('Skald button is enabled and navigates to /skald', () => {
+  it('Skald button is disabled when no campaign is loaded', () => {
     render(<AppHeader />)
-    const skaldBtn = screen.getByRole('button', { name: /skald/i })
-    expect((skaldBtn as HTMLButtonElement).disabled).toBe(false)
-    fireEvent.click(skaldBtn)
-    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+    expect(screen.getByRole('button', { name: /skald/i })).toHaveProperty('disabled', true)
   })
 
   it('World Forge button is disabled', () => {
@@ -72,13 +69,18 @@ describe('AppHeader — navigation', () => {
   })
 })
 
-describe('AppHeader — Iron Sheet gating', () => {
+describe('AppHeader — session-gated tabs', () => {
   it('Iron Sheet button is disabled when no campaign is loaded', () => {
     render(<AppHeader />)
     expect(screen.getByRole('button', { name: /iron sheet/i })).toHaveProperty('disabled', true)
   })
 
-  it('Iron Sheet button is enabled when a campaign is loaded', () => {
+  it('Skald button is disabled when no campaign is loaded', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('button', { name: /skald/i })).toHaveProperty('disabled', true)
+  })
+
+  it('Iron Sheet and Skald buttons are enabled when a campaign is loaded', () => {
     useGameStore.setState({
       campaign: {
         id: 'c1',
@@ -92,9 +94,9 @@ describe('AppHeader — Iron Sheet gating', () => {
       },
     })
     render(<AppHeader />)
-    const ironSheetBtn = screen.getByRole('button', { name: /iron sheet/i })
-    expect(ironSheetBtn).toHaveProperty('disabled', false)
-    fireEvent.click(ironSheetBtn)
+    expect(screen.getByRole('button', { name: /iron sheet/i })).toHaveProperty('disabled', false)
+    expect(screen.getByRole('button', { name: /skald/i })).toHaveProperty('disabled', false)
+    fireEvent.click(screen.getByRole('button', { name: /iron sheet/i }))
     expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')
   })
 })

--- a/apps/web/src/components/AppHeader/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader/AppHeader.tsx
@@ -1,0 +1,47 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useGameStore } from '@/store'
+import styles from './AppHeader.module.css'
+
+const NAV_ITEMS = [
+  { label: 'Iron Sheet', path: '/iron-sheet' },
+  { label: 'Oracle', path: '/oracle' },
+  { label: 'Skald', path: '/skald' },
+  { label: 'World Forge', path: null },
+]
+
+export function AppHeader() {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const campaign = useGameStore((state) => state.campaign)
+
+  return (
+    <header className={styles.header} role="banner">
+      <button
+        type="button"
+        className={styles.logoBtn}
+        aria-label="Go to Great Hall"
+        aria-current={pathname === '/great-hall' ? 'page' : undefined}
+        onClick={() => navigate('/great-hall')}
+      >
+        <span className={styles.logoTitle}>Saga Keeper</span>
+      </button>
+      <nav className={styles.nav} aria-label="Application">
+        {NAV_ITEMS.map(({ label, path }) => {
+          const enabled = path === '/iron-sheet' ? campaign != null : path !== null
+          return (
+            <button
+              key={label}
+              type="button"
+              className={styles.navBtn}
+              aria-current={path === pathname ? 'page' : undefined}
+              disabled={!enabled}
+              onClick={enabled && path ? () => navigate(path) : undefined}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </nav>
+    </header>
+  )
+}

--- a/apps/web/src/components/AppHeader/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader/AppHeader.tsx
@@ -36,7 +36,8 @@ export function AppHeader() {
       </button>
       <nav className={styles.nav} aria-label="Application">
         {NAV_ITEMS.map(({ label, path }) => {
-          const enabled = path === '/iron-sheet' ? campaign != null : path !== null
+          const sessionRequired = path === '/iron-sheet' || path === '/skald'
+          const enabled = sessionRequired ? campaign != null : path !== null
           return (
             <button
               key={label}

--- a/apps/web/src/components/AppHeader/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader/AppHeader.tsx
@@ -23,7 +23,16 @@ export function AppHeader() {
         aria-current={pathname === '/great-hall' ? 'page' : undefined}
         onClick={() => navigate('/great-hall')}
       >
-        <span className={styles.logoTitle}>Saga Keeper</span>
+        <svg width="34" height="34" viewBox="0 0 34 34" fill="none" aria-hidden="true">
+          <polygon points="17,2 32,32 2,32" stroke="#d4941a" strokeWidth="1.2" fill="none" opacity="0.6" />
+          <line x1="17" y1="2" x2="17" y2="32" stroke="#d4941a" strokeWidth="0.8" />
+          <line x1="10" y1="16" x2="24" y2="16" stroke="#d4941a" strokeWidth="0.8" opacity="0.7" />
+          <circle cx="17" cy="17" r="2.5" fill="#f0b429" opacity="0.7" />
+        </svg>
+        <div className={styles.logoText}>
+          <span className={styles.logoTitle}>Saga Keeper</span>
+          <span className={styles.logoSub}>Ironsworn Companion</span>
+        </div>
       </button>
       <nav className={styles.nav} aria-label="Application">
         {NAV_ITEMS.map(({ label, path }) => {

--- a/apps/web/src/screens/great-hall/GreatHallScreen.module.css
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.module.css
@@ -1,72 +1,10 @@
 .screen {
   display: grid;
-  grid-template-rows: 47px auto auto 1fr;
+  grid-template-rows: auto auto auto 1fr;
   min-height: 100vh;
   background: var(--color-void, #0d0b08);
   color: var(--color-parchment, #c4a96e);
   font-family: 'Cinzel', Georgia, serif;
-}
-
-/* ── HEADER ── */
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 32px;
-  border-bottom: 1px solid rgba(212, 148, 26, 0.2);
-  background: rgba(30, 23, 16, 0.95);
-  backdrop-filter: blur(8px);
-}
-
-.logoBtn {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-}
-
-.logoTitle {
-  font-family: 'Cinzel Decorative', serif;
-  font-size: 14px;
-  font-weight: 900;
-  color: var(--color-gold-bright, #f0b429);
-  letter-spacing: 3px;
-  text-transform: uppercase;
-}
-
-.headerNav {
-  display: flex;
-  gap: 2px;
-}
-
-.navBtn {
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--color-bone, #7a6a52);
-  padding: 6px 14px;
-  font-family: 'Cinzel', serif;
-  font-size: 10px;
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: all 0.2s;
-  border-radius: 2px;
-  height: 47px;
-}
-
-.navBtn:hover,
-.navBtn[aria-current='page'] {
-  border-color: rgba(212, 148, 26, 0.4);
-  color: var(--color-gold, #d4941a);
-  background: rgba(212, 148, 26, 0.08);
-}
-
-.navBtn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
 }
 
 /* ── MAIN BODY ── */

--- a/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
@@ -195,17 +195,10 @@ describe('GreatHallScreen — navigation', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/oracle')
   })
 
-  it('Skald nav button calls navigate("/skald")', async () => {
+  it('Skald nav button is disabled when no campaign is loaded', async () => {
     render(<GreatHallScreen />)
     await waitFor(() => screen.getByRole('button', { name: /skald/i }))
-    const nav = screen.getByRole('navigation', { name: /application/i })
-    const skaldBtn = nav.querySelector('button[data-navkey="skald"]') as HTMLButtonElement | null
-    // Find by accessible name within nav
-    const btns = Array.from(nav.querySelectorAll('button')) as HTMLButtonElement[]
-    const skald = btns.find((b) => /skald/i.test(b.textContent ?? ''))
-    expect(skald).toBeTruthy()
-    fireEvent.click(skald!)
-    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+    expect((screen.getByRole('button', { name: /skald/i }) as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('World Forge nav button is disabled', async () => {

--- a/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.test.tsx
@@ -182,11 +182,10 @@ describe('GreatHallScreen — navigation', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
   })
 
-  it('Iron Sheet nav button calls navigate("/iron-sheet")', async () => {
+  it('Iron Sheet nav button is disabled when no campaign is loaded', async () => {
     render(<GreatHallScreen />)
     await waitFor(() => screen.getByRole('button', { name: /iron sheet/i }))
-    fireEvent.click(screen.getByRole('button', { name: /iron sheet/i }))
-    expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')
+    expect((screen.getByRole('button', { name: /iron sheet/i }) as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('Oracle nav button calls navigate("/oracle")', async () => {

--- a/apps/web/src/screens/great-hall/GreatHallScreen.tsx
+++ b/apps/web/src/screens/great-hall/GreatHallScreen.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import type { CampaignSummary } from '@saga-keeper/domain'
 import type { IronswornCharacterData, IronswornVow } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
 import { useCampaignOps } from '@/providers/NarrativeDomainProvider'
+import { AppHeader } from '@/components/AppHeader/AppHeader'
 import { HeroSection } from './components/HeroSection/HeroSection'
 import { StatsBar } from './components/StatsBar/StatsBar'
 import { CampaignCard } from './components/CampaignCard/CampaignCard'
@@ -13,16 +14,8 @@ import { sessionEventsToActivityItems } from './utils/sessionEventsToActivityIte
 import { deriveReminderText } from './utils/deriveReminderText'
 import styles from './GreatHallScreen.module.css'
 
-const NAV_ITEMS = [
-  { label: 'Iron Sheet', path: '/iron-sheet' },
-  { label: 'Oracle', path: '/oracle' },
-  { label: 'Skald', path: '/skald' },
-  { label: 'World Forge', path: null },
-]
-
 export function GreatHallScreen() {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
   const { listCampaigns, loadCampaign } = useCampaignOps()
 
   const [campaigns, setCampaigns] = useState<CampaignSummary[]>([])
@@ -68,31 +61,7 @@ export function GreatHallScreen() {
 
   return (
     <div className={styles.screen}>
-      <header className={styles.header} role="banner">
-        <button
-          type="button"
-          className={styles.logoBtn}
-          aria-label="Go to Great Hall"
-          aria-current={pathname === '/great-hall' ? 'page' : undefined}
-          onClick={() => navigate('/great-hall')}
-        >
-          <span className={styles.logoTitle}>Saga Keeper</span>
-        </button>
-        <nav className={styles.headerNav} aria-label="Application">
-          {NAV_ITEMS.map(({ label, path }) => (
-            <button
-              key={label}
-              type="button"
-              className={styles.navBtn}
-              aria-current={path === pathname ? 'page' : undefined}
-              disabled={path === null}
-              onClick={path ? () => navigate(path) : undefined}
-            >
-              {label}
-            </button>
-          ))}
-        </nav>
-      </header>
+      <AppHeader />
 
       <HeroSection />
 

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.module.css
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.module.css
@@ -1,68 +1,10 @@
 .screen {
   display: grid;
-  grid-template-rows: 47px 1fr;
+  grid-template-rows: auto 1fr;
   min-height: 100vh;
   background: var(--color-void, #0d0b08);
   color: var(--color-parchment, #c4a96e);
   font-family: 'Cinzel', Georgia, serif;
-}
-
-/* ── HEADER ── */
-.header {
-  grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 32px;
-  border-bottom: 1px solid rgba(212, 148, 26, 0.2);
-  background: rgba(30, 23, 16, 0.95);
-  backdrop-filter: blur(8px);
-}
-
-.logoBtn {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-}
-
-.logoTitle {
-  font-family: 'Cinzel Decorative', serif;
-  font-size: 14px;
-  font-weight: 900;
-  color: var(--color-gold-bright, #f0b429);
-  letter-spacing: 3px;
-  text-transform: uppercase;
-}
-
-.headerNav {
-  display: flex;
-  gap: 2px;
-}
-
-.navBtn {
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--color-bone, #7a6a52);
-  padding: 6px 14px;
-  font-family: 'Cinzel', serif;
-  font-size: 10px;
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: all 0.2s;
-  border-radius: 2px;
-  height: 47px;
-}
-
-.navBtn:hover,
-.navBtn[aria-current='page'] {
-  border-color: rgba(212, 148, 26, 0.4);
-  color: var(--color-gold, #d4941a);
-  background: rgba(212, 148, 26, 0.08);
 }
 
 /* ── BODY ── */

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.test.tsx
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.test.tsx
@@ -194,11 +194,8 @@ describe('IronSheetScreen — accessibility', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/oracle')
   })
 
-  it('Skald nav button is enabled and navigates to /skald', () => {
+  it('Skald nav button is disabled when no campaign is loaded', () => {
     render(<IronSheetScreen />)
-    const skaldBtn = screen.getByRole('button', { name: /skald/i })
-    expect((skaldBtn as HTMLButtonElement).disabled).toBe(false)
-    fireEvent.click(skaldBtn)
-    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+    expect(screen.getByRole('button', { name: /skald/i })).toHaveProperty('disabled', true)
   })
 })

--- a/apps/web/src/screens/iron-sheet/IronSheetScreen.tsx
+++ b/apps/web/src/screens/iron-sheet/IronSheetScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
 import { ironswornPlugin, type IronswornCharacterData } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
+import { AppHeader } from '@/components/AppHeader/AppHeader'
 import { CharacterHeader } from './components/CharacterHeader/CharacterHeader'
 import { StatsGrid } from './components/StatsGrid/StatsGrid'
 import type { StatKey } from './components/StatsGrid/StatsGrid'
@@ -12,16 +12,7 @@ import { VowTracker } from './components/VowTracker/VowTracker'
 import { DiceRollerSection } from './components/DiceRollerSection/DiceRollerSection'
 import styles from './IronSheetScreen.module.css'
 
-const NAV_ITEMS = [
-  { label: 'Iron Sheet', path: '/iron-sheet' },
-  { label: 'Oracle', path: '/oracle' },
-  { label: 'Skald', path: '/skald' },
-  { label: 'World Forge', path: null },
-]
-
 export function IronSheetScreen() {
-  const navigate = useNavigate()
-  const { pathname } = useLocation()
   const character = useGameStore((state) => state.character)
   const patchCharacterData = useGameStore((state) => state.patchCharacterData)
   const [selectedStat, setSelectedStat] = useState<StatKey | null>(null)
@@ -33,7 +24,7 @@ export function IronSheetScreen() {
   if (!character) {
     return (
       <div className={styles.screen}>
-        {renderHeader(navigate, pathname)}
+        <AppHeader />
         <main className={styles.empty} role="main" tabIndex={-1}>
           <p>No character loaded</p>
         </main>
@@ -63,7 +54,7 @@ export function IronSheetScreen() {
 
   return (
     <div className={styles.screen}>
-      {renderHeader(navigate, pathname)}
+      <AppHeader />
       <div className={styles.body}>
         <aside className={styles.sidebar}>{/* Session nav placeholder */}</aside>
         <main className={styles.main} role="main" tabIndex={-1}>
@@ -104,34 +95,5 @@ export function IronSheetScreen() {
         </main>
       </div>
     </div>
-  )
-}
-
-function renderHeader(navigate: ReturnType<typeof useNavigate>, currentPath: string) {
-  return (
-    <header className={styles.header}>
-      <button
-        type="button"
-        className={styles.logoBtn}
-        aria-label="Go to Great Hall"
-        onClick={() => navigate('/great-hall')}
-      >
-        <span className={styles.logoTitle}>Saga Keeper</span>
-      </button>
-      <nav className={styles.headerNav} aria-label="Application">
-        {NAV_ITEMS.map(({ label, path }) => (
-          <button
-            key={label}
-            type="button"
-            className={styles.navBtn}
-            aria-current={path === currentPath ? 'page' : undefined}
-            disabled={path === null}
-            onClick={path ? () => navigate(path) : undefined}
-          >
-            {label}
-          </button>
-        ))}
-      </nav>
-    </header>
   )
 }

--- a/apps/web/src/screens/oracle/OracleScreen.module.css
+++ b/apps/web/src/screens/oracle/OracleScreen.module.css
@@ -1,68 +1,10 @@
 .screen {
   display: grid;
-  grid-template-rows: 47px 1fr;
+  grid-template-rows: auto 1fr;
   min-height: 100vh;
   background: var(--color-void, #0d0b08);
   color: var(--color-parchment, #c4a96e);
   font-family: 'Cinzel', Georgia, serif;
-}
-
-/* ── HEADER ── */
-.header {
-  grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 32px;
-  border-bottom: 1px solid rgba(212, 148, 26, 0.2);
-  background: rgba(30, 23, 16, 0.95);
-  backdrop-filter: blur(8px);
-}
-
-.logoBtn {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-}
-
-.logoTitle {
-  font-family: 'Cinzel Decorative', serif;
-  font-size: 14px;
-  font-weight: 900;
-  color: var(--color-gold-bright, #f0b429);
-  letter-spacing: 3px;
-  text-transform: uppercase;
-}
-
-.headerNav {
-  display: flex;
-  gap: 2px;
-}
-
-.navBtn {
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--color-bone, #7a6a52);
-  padding: 6px 14px;
-  font-family: 'Cinzel', serif;
-  font-size: 10px;
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: all 0.2s;
-  border-radius: 2px;
-  height: 47px;
-}
-
-.navBtn:hover,
-.navBtn[aria-current='page'] {
-  border-color: rgba(212, 148, 26, 0.4);
-  color: var(--color-gold, #d4941a);
-  background: rgba(212, 148, 26, 0.08);
 }
 
 /* ── BODY ── */

--- a/apps/web/src/screens/oracle/OracleScreen.test.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.test.tsx
@@ -98,11 +98,8 @@ describe('OracleScreen — accessibility', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/great-hall')
   })
 
-  it('Skald nav button is enabled and navigates to /skald', () => {
+  it('Skald nav button is disabled when no campaign is loaded', () => {
     render(<OracleScreen />)
-    const skaldBtn = screen.getByRole('button', { name: /skald/i })
-    expect((skaldBtn as HTMLButtonElement).disabled).toBe(false)
-    fireEvent.click(skaldBtn)
-    expect(mockNavigate).toHaveBeenCalledWith('/skald')
+    expect(screen.getByRole('button', { name: /skald/i })).toHaveProperty('disabled', true)
   })
 })

--- a/apps/web/src/screens/oracle/OracleScreen.test.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.test.tsx
@@ -40,7 +40,24 @@ describe('OracleScreen — layout', () => {
     expect(ironSheetBtn.getAttribute('aria-current')).toBeNull()
   })
 
-  it('clicking Iron Sheet nav calls navigate with /iron-sheet', () => {
+  it('Iron Sheet nav button is disabled when no campaign is loaded', () => {
+    render(<OracleScreen />)
+    expect(screen.getByRole('button', { name: /iron sheet/i })).toHaveProperty('disabled', true)
+  })
+
+  it('clicking Iron Sheet nav calls navigate with /iron-sheet when campaign is loaded', () => {
+    useGameStore.setState({
+      campaign: {
+        id: 'c1',
+        name: 'Test',
+        rulesetId: 'ironsworn-v1',
+        status: 'active' as const,
+        mode: 'solo' as const,
+        characterIds: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    })
     render(<OracleScreen />)
     fireEvent.click(screen.getByRole('button', { name: /iron sheet/i }))
     expect(mockNavigate).toHaveBeenCalledWith('/iron-sheet')

--- a/apps/web/src/screens/oracle/OracleScreen.tsx
+++ b/apps/web/src/screens/oracle/OracleScreen.tsx
@@ -1,22 +1,13 @@
-import { useNavigate, useLocation } from 'react-router-dom'
 import { ironswornPlugin } from '@saga-keeper/ruleset-ironsworn'
 import { useGameStore } from '@/store'
+import { AppHeader } from '@/components/AppHeader/AppHeader'
 import { OracleTableBrowser } from './components/OracleTableBrowser/OracleTableBrowser'
 import { AskFatesPanel } from './components/AskFatesPanel/AskFatesPanel'
 import { OracleTableRollPanel } from './components/OracleTableRollPanel/OracleTableRollPanel'
 import { OracleHistory } from './components/OracleHistory/OracleHistory'
 import styles from './OracleScreen.module.css'
 
-const NAV_ITEMS = [
-  { label: 'Iron Sheet', path: '/iron-sheet' },
-  { label: 'Oracle', path: '/oracle' },
-  { label: 'Skald', path: '/skald' },
-  { label: 'World Forge', path: null },
-]
-
 export function OracleScreen() {
-  const navigate = useNavigate()
-  const { pathname } = useLocation()
   const tables = ironswornPlugin.oracle.getTables()
   const draft = useGameStore((state) => state.draft)
   const lastFates = useGameStore((state) => state.lastFates)
@@ -44,30 +35,7 @@ export function OracleScreen() {
 
   return (
     <div className={styles.screen}>
-      <header className={styles.header} role="banner">
-        <button
-          type="button"
-          className={styles.logoBtn}
-          aria-label="Go to Great Hall"
-          onClick={() => navigate('/great-hall')}
-        >
-          <span className={styles.logoTitle}>Saga Keeper</span>
-        </button>
-        <nav className={styles.headerNav} aria-label="Application">
-          {NAV_ITEMS.map(({ label, path }) => (
-            <button
-              key={label}
-              type="button"
-              className={styles.navBtn}
-              aria-current={path === pathname ? 'page' : undefined}
-              disabled={path === null}
-              onClick={path ? () => navigate(path) : undefined}
-            >
-              {label}
-            </button>
-          ))}
-        </nav>
-      </header>
+      <AppHeader />
       <div className={styles.body}>
         <aside className={styles.sidebar} aria-label="Oracle Tables">
           <OracleTableBrowser


### PR DESCRIPTION
## Summary

- Extracts the duplicated `<header>` / `<nav>` markup from `GreatHallScreen`, `OracleScreen`, and `IronSheetScreen` into a single `AppHeader` component (`apps/web/src/components/AppHeader/`)
- **Iron Sheet** and **Skald** nav tabs are disabled when no campaign is loaded — both require an active session, so they follow the same gating rule
- Logo displays the rune SVG icon + "Ironsworn Companion" subtitle alongside "Saga Keeper"
- Oracle and the logo (Great Hall) are always accessible; World Forge remains disabled

## What changed

| File | Change |
|------|--------|
| `src/components/AppHeader/AppHeader.tsx` | New shared header component |
| `src/components/AppHeader/AppHeader.module.css` | Styles |
| `src/components/AppHeader/AppHeader.test.tsx` | 12 tests (structure, navigation, session-gated tabs) |
| `GreatHallScreen.tsx` | Replaced inline header with `<AppHeader />` |
| `OracleScreen.tsx` | Replaced inline header with `<AppHeader />` |
| `IronSheetScreen.tsx` | Replaced `renderHeader()` helper with `<AppHeader />` |
| `*Screen.test.tsx` | Updated nav tests to reflect gating rules |

## Test plan

- [x] `pnpm test` — 691 tests passing (49 test files)
- [x] `pnpm typecheck` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)